### PR TITLE
Fix issue #294

### DIFF
--- a/l5r/widgets/requirementwidget.py
+++ b/l5r/widgets/requirementwidget.py
@@ -142,7 +142,7 @@ class RequirementsWidget(QtGui.QWidget):
         return True
 
     def match_at_least_one(self):
-        if len(self.checks) == 0:
+        if not self.checks[0].isVisible():
             return True
         for c in self.checks:
             if c.isChecked():


### PR DESCRIPTION
The list of checks always have 10 items. So instead of using its length to check if there is any requirement at all I'm using the visibility of the first check-box.