### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/OpenNingia/l5r-character-manager-3/security/code-scanning/1](https://github.com/OpenNingia/l5r-character-manager-3/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block at the job level (for `build`), listing only the privileges required for the workflow steps. Based on the actions used:
- `actions/create-release` and `actions/upload-release-asset` require:
  - `contents: write` (to upload and manipulate release assets)
- If no other privileges are needed, do not add unnecessary ones.

This fix involves adding a `permissions` key under the `build:` job (after line 15 and before `runs-on:` line 16) with the required minimum permissions:
```yaml
permissions:
  contents: write
```
No extra methods, imports, or definitions are needed as changes are purely to the workflow YML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
