### PR TITLE
fix: restore wildcard skill choices when loading a saved character (#397)

### DIFF
--- a/l5r/models/chmodel.py
+++ b/l5r/models/chmodel.py
@@ -102,6 +102,36 @@ class MyJsonEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
+def _wildcard_set_from_dict(value):
+    """Rebuild a SchoolSkillWildcardSet from its JSON dict representation.
+
+    Pending skill choices stored on a rank advancement are
+    ``SchoolSkillWildcardSet`` instances. They are serialised to plain dicts
+    by ``MyJsonEncoder`` and would stay dicts on load, breaking attribute
+    access such as ``ws.wildcards``. Anything that is not a dict (e.g. an
+    already-rebuilt object) is returned unchanged.
+    """
+    if not isinstance(value, dict):
+        return value
+
+    wc_set = l5rdal.school.SchoolSkillWildcardSet()
+    for k, v in value.items():
+        setattr(wc_set, k, v)
+
+    wildcards = []
+    for wc in value.get('wildcards', []) or []:
+        if isinstance(wc, dict):
+            wildcard = l5rdal.school.SchoolSkillWildcard()
+            for k, v in wc.items():
+                setattr(wildcard, k, v)
+            wildcards.append(wildcard)
+        else:
+            wildcards.append(wc)
+    wc_set.wildcards = wildcards
+
+    return wc_set
+
+
 class AdvancedPcModel(object):
 
     def __init__(self):
@@ -235,6 +265,16 @@ class AdvancedPcModel(object):
             for ad in obj['advans']:
                 a = adv.Advancement(None, None)
                 _load_obj(deepcopy(ad), a)
+                # ``skills_to_choose`` on a rank advancement holds
+                # SchoolSkillWildcardSet objects. JSON serialisation turns
+                # them into plain dicts, so restore them to objects here;
+                # otherwise reading ``ws.wildcards`` later raises
+                # AttributeError on the loaded character.
+                if getattr(a, 'type', None) == 'rank':
+                    a.skills_to_choose = [
+                        _wildcard_set_from_dict(ws)
+                        for ws in getattr(a, 'skills_to_choose', [])
+                    ]
                 self.advans.append(a)
 
             # armor

--- a/l5r/models/tests/test_load_save.py
+++ b/l5r/models/tests/test_load_save.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+import contextlib
+import os
+import tempfile
+import unittest
+
+import l5rdal as dal
+from l5rdal.school import SchoolSkillWildcard, SchoolSkillWildcardSet
+
+import l5r.api as api
+import l5r.api.data
+import l5r.api.data.families
+import l5r.api.data.skills
+import l5r.api.character
+import l5r.api.character.rankadv
+import l5r.api.character.schools
+from l5r.api.context import L5RCMContext, use
+from l5r.models.chmodel import AdvancedPcModel
+from l5r.tests.fakedata import *
+
+
+class TestLoadSavePendingChoices(unittest.TestCase):
+    """Regression tests for the character save/load round-trip.
+
+    A character saved with pending skill choices used to break on reload:
+    the ``SchoolSkillWildcardSet`` objects stored in a rank advancement's
+    ``skills_to_choose`` were serialised to plain dicts and never restored,
+    so reading ``ws.wildcards`` raised ``AttributeError``.
+    """
+
+    def setUp(self):
+        self._stack = contextlib.ExitStack()
+        self.addCleanup(self._stack.close)
+        self._stack.enter_context(use(L5RCMContext()))
+
+        data_ = dal.Data([], [])
+        api.data.set_model(data_)
+
+        data_.clans.append(test_clan_1)
+        data_.families.append(test_family_1)
+
+        # A school that grants a pending wildcard skill choice
+        # ("any skill from category test_skill_categ_1, rank 1").
+        wildcard = SchoolSkillWildcard()
+        wildcard.value = 'test_skill_categ_1'
+        wildcard.modifier = 'or'
+
+        wildcard_set = SchoolSkillWildcardSet()
+        wildcard_set.rank = 1
+        wildcard_set.wildcards = [wildcard]
+
+        test_school_1.skills_pc = [wildcard_set]
+        data_.schools.append(test_school_1)
+
+        self.addCleanup(lambda: setattr(test_school_1, 'skills_pc', []))
+
+        api.character.new()
+        api.character.schools.set_first('test_school_1')
+
+    def _get_rank_skills_to_choose(self, model):
+        api.character.set_model(model)
+        return api.character.rankadv.get_starting_skills_to_choose()
+
+    def test_pending_choice_present_before_save(self):
+        """Sanity check: the in-memory character has the wildcard set."""
+        to_choose = api.character.rankadv.get_starting_skills_to_choose()
+        self.assertEqual(1, len(to_choose))
+        self.assertEqual('test_skill_categ_1', to_choose[0].wildcards[0].value)
+
+    def test_round_trip_preserves_wildcard_objects(self):
+        """Saving then loading must keep ``skills_to_choose`` as objects."""
+        model = api.character.model()
+
+        fd, path = tempfile.mkstemp(suffix='.l5r')
+        os.close(fd)
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+
+        self.assertTrue(model.save_to(path))
+
+        loaded = AdvancedPcModel()
+        self.assertTrue(loaded.load_from(path))
+
+        to_choose = self._get_rank_skills_to_choose(loaded)
+
+        # This attribute access used to raise:
+        #   AttributeError: 'dict' object has no attribute 'wildcards'
+        self.assertEqual(1, len(to_choose))
+        wildcard_set = to_choose[0]
+        self.assertIsInstance(wildcard_set, SchoolSkillWildcardSet)
+        self.assertEqual(1, wildcard_set.rank)
+        self.assertEqual(1, len(wildcard_set.wildcards))
+
+        wildcard = wildcard_set.wildcards[0]
+        self.assertIsInstance(wildcard, SchoolSkillWildcard)
+        self.assertEqual('test_skill_categ_1', wildcard.value)
+        self.assertEqual('or', wildcard.modifier)


### PR DESCRIPTION
## Summary

- A character saved with pending starting-skill choices raised `AttributeError: 'dict' object has no attribute 'wildcards'` when making a skill choice after reopening.
- `skills_to_choose` on rank advancements holds `SchoolSkillWildcardSet` objects, which `MyJsonEncoder` serialises to plain dicts. `load_from` never re-instantiated them, so attribute access crashed.

## Changes

- `l5r/models/chmodel.py`: added `_wildcard_set_from_dict()` to rebuild `SchoolSkillWildcardSet`/`SchoolSkillWildcard` objects from their JSON dict form; applied in `load_from` for rank advancements' `skills_to_choose`.
- `l5r/models/tests/test_load_save.py`: full save→load round-trip regression test (fails without the fix, passes with it).

Fixes #397