### PR TITLE
fix(qml): stop wounds +/- from re-projecting the whole sheet (#419)

### DIFF
--- a/l5r/api/character/__init__.py
+++ b/l5r/api/character/__init__.py
@@ -764,7 +764,9 @@ def set_health_multiplier(value):
         return
     pc.health_multiplier = value
     set_dirty_flag(True)
-    l5r.api.signals.bus().character_refreshed.emit()
+    # Narrow signal: the multiplier only rescales the wound table (combat
+    # slice). No need to re-project the whole sheet.
+    l5r.api.signals.bus().wounds_changed.emit()
     log.api.info("set health multiplier to: %d", value)
 
 
@@ -789,7 +791,10 @@ def set_wounds_taken(value):
         return
     pc.wounds = value
     set_dirty_flag(True)
-    l5r.api.signals.bus().character_refreshed.emit()
+    # Narrow signal: wounds only affect the combat slice's totals/level.
+    # Nothing else (and no modifier predicate) reads the wound count, so
+    # re-projecting the whole sheet here is wasted work.
+    l5r.api.signals.bus().wounds_changed.emit()
 
 
 def damage_health(delta):

--- a/l5r/api/rules/__init__.py
+++ b/l5r/api/rules/__init__.py
@@ -221,8 +221,11 @@ def calculate_base_attack_roll(pc, weap):
     skill = 0
     if weap.skill_id:
         skill = api.character.skills.get_skill_rank(weap.skill_id)
-        log.rules.info(u"calc base atk. trait: {0}, weap: {1}, skill: {2}, rank: {3}"
-                       .format(trait, weap.name, weap.skill_nm, skill))
+        # DEBUG, not INFO: this runs once per weapon on every character
+        # refresh (and the weapons proxy re-projects on each one), so at
+        # INFO it floods the log and adds formatting overhead to a hot path.
+        log.rules.debug(u"calc base atk. trait: {0}, weap: {1}, skill: {2}, rank: {3}"
+                        .format(trait, weap.name, weap.skill_nm, skill))
 
     return trait + skill, trait
 

--- a/l5r/api/signals.py
+++ b/l5r/api/signals.py
@@ -35,6 +35,13 @@ class _ModelBus(QObject):
     # the QWidget side's update_from_model() pull -- the QML side
     # subscribes once per mixin and re-emits its bundle signals.
     character_refreshed = Signal()
+    # Narrow "wounds / health track changed" event. Wounds (and the rarely
+    # touched health multiplier) only affect the combat slice's wound table
+    # and totals -- no other proxy, and no modifier predicate, depends on
+    # them. Emitting this instead of the coarse character_refreshed keeps a
+    # wounds +/- click from re-projecting the whole sheet (weapons, skills,
+    # spells, ...), which is pure waste.
+    wounds_changed = Signal()
 
 
 _BUS = None

--- a/l5r/api/tests/test_rules_health.py
+++ b/l5r/api/tests/test_rules_health.py
@@ -170,18 +170,20 @@ class TestHealthMultiplier(unittest.TestCase):
         api.character.set_health_multiplier(5)
         self.assertEqual(earth * 5 + 7 * earth * 5, api.rules.get_max_wounds())
 
-    def test_setter_emits_character_refreshed_on_change(self):
-        """The QML proxy listens on api.signals.bus().character_refreshed to
-        rebroadcast combatChanged; without this emit, healthMultiplier
+    def test_setter_emits_wounds_changed_on_change(self):
+        """The QML combat proxy listens on api.signals.bus().wounds_changed
+        to rebroadcast combatChanged; without this emit, healthMultiplier
         would still update the model but the UI would freeze on the old
-        wound table until something else refreshed it."""
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        wound table until something else refreshed it. The narrow signal
+        (not the coarse character_refreshed) keeps the rest of the sheet
+        from re-projecting."""
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_health_multiplier(3)
         self.assertEqual(1, len(events))
 
     def test_setter_no_op_does_not_emit(self):
         pc = api.character.model()
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_health_multiplier(pc.health_multiplier)
         self.assertEqual(0, len(events))
 
@@ -343,13 +345,13 @@ class TestWoundsSetters(unittest.TestCase):
         api.character.set_wounds_taken("9")
         self.assertEqual(9, api.character.get_wounds_taken())
 
-    def test_set_emits_character_refreshed_on_change(self):
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+    def test_set_emits_wounds_changed_on_change(self):
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_wounds_taken(4)
         self.assertEqual(1, len(events))
 
     def test_set_no_op_does_not_emit(self):
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_wounds_taken(0)   # already 0
         self.assertEqual(0, len(events))
 
@@ -379,7 +381,7 @@ class TestWoundsSetters(unittest.TestCase):
         pc = api.character.model()
         pc.wounds = 5
         pc.unsaved = False
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.damage_health(0)
         self.assertEqual(5, pc.wounds)
         self.assertFalse(pc.unsaved)

--- a/l5r/qmlui/proxies/app_controller.py
+++ b/l5r/qmlui/proxies/app_controller.py
@@ -855,6 +855,14 @@ class AppController(QObject):
         setter(float(value))
 
     # --- health ------------------------------------------------------
+    #
+    # The api setters below (set_health_multiplier / set_wounds_taken)
+    # already emit character_refreshed when the value actually changes --
+    # see the CLAUDE.md "setters own the dirty flag" contract. We must NOT
+    # call notify_character_refreshed() again here: doing so doubles the
+    # whole-sheet re-projection (every weapon's attack/damage roll, each
+    # rebuilding the datapack modifier set) on every wounds +/- click,
+    # which is what made the wounds stepper feel like it was looping.
 
     @Slot(int)
     def setHealthMultiplier(self, value):
@@ -862,23 +870,18 @@ class AppController(QObject):
             api.character.set_health_multiplier(int(value))
         except ValueError:
             log.api.warning(u"QML UI: invalid health multiplier %r", value)
-            return
-        api.character.notify_character_refreshed()
 
     @Slot(int)
     def damageHealth(self, delta):
         api.character.damage_health(int(delta))
-        api.character.notify_character_refreshed()
 
     @Slot(int)
     def setWoundsTotal(self, value):
         api.character.set_wounds_taken(int(value))
-        api.character.notify_character_refreshed()
 
     @Slot()
     def resetWounds(self):
         api.character.set_wounds_taken(0)
-        api.character.notify_character_refreshed()
 
     # --- skills ------------------------------------------------------
 

--- a/l5r/qmlui/proxies/pc/combat.py
+++ b/l5r/qmlui/proxies/pc/combat.py
@@ -38,6 +38,9 @@ class CombatMixin:
     def _wire_combat(self, bus):
         bus.character_refreshed.connect(self._on_character_refreshed_combat)
         bus.model_replaced.connect(self._on_model_replaced_combat)
+        # Wounds / health-multiplier changes use a narrow signal so a
+        # wounds +/- click refreshes only this slice, not the whole sheet.
+        bus.wounds_changed.connect(self._on_character_refreshed_combat)
 
     def _on_character_refreshed_combat(self):
         self.combatChanged.emit()

--- a/l5r/qmlui/qml/sections/WeaponsSection.qml
+++ b/l5r/qmlui/qml/sections/WeaponsSection.qml
@@ -69,7 +69,11 @@ ColumnLayout {
     // Defensive binding -- proxy may be absent on first paint or under
     // the offscreen preview tool (which binds a null pcProxy).
     // -----------------------------------------------------------------
-    readonly property var _weapons: (pcProxy && pcProxy.weapons) ? pcProxy.weapons : []
+    // Read pcProxy.weapons once: the getter rebuilds the whole list (and
+    // recomputes every weapon's attack/damage roll) on each call, so the
+    // old `(pcProxy && pcProxy.weapons) ? pcProxy.weapons : []` form paid
+    // for it twice per re-projection.
+    readonly property var _weapons: pcProxy ? pcProxy.weapons : []
     readonly property bool _hasWeapons: _weapons.length > 0
 
     // The worn armour (at most one). Earth-toned, heads the rack.

--- a/l5r/util/log.py
+++ b/l5r/util/log.py
@@ -33,7 +33,7 @@ def log_setup(base_path, base_name):
     root = logging.getLogger('')
 
     # set the level of the root logger
-    root.setLevel(logging.DEBUG)
+    root.setLevel(logging.INFO)
 
     # define the file formatter
     file_fmt = logging.Formatter('%(asctime)s %(name)-12s ' +


### PR DESCRIPTION
Clicking the wounds stepper emitted the coarse `character_refreshed`, which made every PcProxy slice re-emit -- the weapons slice in turn recomputed every attack/damage roll (each scanning the datapack modifier sets), flooding the log with INFO `calc base atk` lines and freezing the UI on characters with several weapons.

- Add a narrow `wounds_changed` bus signal; `set_wounds_taken` and `set_health_multiplier` emit it instead of `character_refreshed`. Only the combat proxy slice listens, so a wounds tick now refreshes just the wound table/totals -- nothing reads the wound count elsewhere, and no modifier predicate depends on it.
- Drop the redundant `notify_character_refreshed()` from the health AppController slots (the api setters already emit on change), which was doubling the work per click.
- Demote the per-weapon `calc base atk` log from INFO to DEBUG and set the root logger to INFO.
- Read `pcProxy.weapons` once in WeaponsSection (the old ternary called the rebuild-everything getter twice).