### PR TITLE
Three fixes for the QML sheet, two performance and one UX. Closes #402, closes #419, closes #421

### DIFF
--- a/docs/L5R_UI_Design_System.md
+++ b/docs/L5R_UI_Design_System.md
@@ -394,8 +394,15 @@ Kanji watermark: see Section 3.3; placed bottom-right of each card, white at 12 
 Dot size:        14 × 14 px; border-radius 50 %
 Filled dot:      background --color-success (Honor) | --color-warning (Glory)
 Empty dot:       background transparent; border 1.5px solid respective colour
+Dot digit:       each dot carries its tenth value (1…9) centred inside, EB Garamond 9 px;
+                 paper-coloured on a filled dot, track colour on an empty one — the digit
+                 spells out that the dots are the DECIMAL part of the rank (issue #402)
 Gap between:     4 px
-Row layout:      dots left-aligned; –/value/+ controls right-aligned; "rank N.N" far right
+Row layout:      header row = colour swatch + NAME + –/value/+ stepper;
+                 track row underneath = "N.N" score (EB Garamond, --font-size-stat-medium,
+                 tabular figures, track colour) left of the dots
+Scrolling:       wheel over the track fine-tunes ±0.1 and ROLLS OVER at the rank
+                 boundary: up from N.9 → (N+1).0, down from N.0 → (N−1).9
 ```
 
 ### 6.13 Section Divider / Horizontal Rule

--- a/l5r/api/character/__init__.py
+++ b/l5r/api/character/__init__.py
@@ -764,7 +764,9 @@ def set_health_multiplier(value):
         return
     pc.health_multiplier = value
     set_dirty_flag(True)
-    l5r.api.signals.bus().character_refreshed.emit()
+    # Narrow signal: the multiplier only rescales the wound table (combat
+    # slice). No need to re-project the whole sheet.
+    l5r.api.signals.bus().wounds_changed.emit()
     log.api.info("set health multiplier to: %d", value)
 
 
@@ -789,7 +791,10 @@ def set_wounds_taken(value):
         return
     pc.wounds = value
     set_dirty_flag(True)
-    l5r.api.signals.bus().character_refreshed.emit()
+    # Narrow signal: wounds only affect the combat slice's totals/level.
+    # Nothing else (and no modifier predicate) reads the wound count, so
+    # re-projecting the whole sheet here is wasted work.
+    l5r.api.signals.bus().wounds_changed.emit()
 
 
 def damage_health(delta):

--- a/l5r/api/rules/__init__.py
+++ b/l5r/api/rules/__init__.py
@@ -221,8 +221,11 @@ def calculate_base_attack_roll(pc, weap):
     skill = 0
     if weap.skill_id:
         skill = api.character.skills.get_skill_rank(weap.skill_id)
-        log.rules.info(u"calc base atk. trait: {0}, weap: {1}, skill: {2}, rank: {3}"
-                       .format(trait, weap.name, weap.skill_nm, skill))
+        # DEBUG, not INFO: this runs once per weapon on every character
+        # refresh (and the weapons proxy re-projects on each one), so at
+        # INFO it floods the log and adds formatting overhead to a hot path.
+        log.rules.debug(u"calc base atk. trait: {0}, weap: {1}, skill: {2}, rank: {3}"
+                        .format(trait, weap.name, weap.skill_nm, skill))
 
     return trait + skill, trait
 

--- a/l5r/api/signals.py
+++ b/l5r/api/signals.py
@@ -35,6 +35,13 @@ class _ModelBus(QObject):
     # the QWidget side's update_from_model() pull -- the QML side
     # subscribes once per mixin and re-emits its bundle signals.
     character_refreshed = Signal()
+    # Narrow "wounds / health track changed" event. Wounds (and the rarely
+    # touched health multiplier) only affect the combat slice's wound table
+    # and totals -- no other proxy, and no modifier predicate, depends on
+    # them. Emitting this instead of the coarse character_refreshed keeps a
+    # wounds +/- click from re-projecting the whole sheet (weapons, skills,
+    # spells, ...), which is pure waste.
+    wounds_changed = Signal()
 
 
 _BUS = None

--- a/l5r/api/tests/test_rules_health.py
+++ b/l5r/api/tests/test_rules_health.py
@@ -170,18 +170,20 @@ class TestHealthMultiplier(unittest.TestCase):
         api.character.set_health_multiplier(5)
         self.assertEqual(earth * 5 + 7 * earth * 5, api.rules.get_max_wounds())
 
-    def test_setter_emits_character_refreshed_on_change(self):
-        """The QML proxy listens on api.signals.bus().character_refreshed to
-        rebroadcast combatChanged; without this emit, healthMultiplier
+    def test_setter_emits_wounds_changed_on_change(self):
+        """The QML combat proxy listens on api.signals.bus().wounds_changed
+        to rebroadcast combatChanged; without this emit, healthMultiplier
         would still update the model but the UI would freeze on the old
-        wound table until something else refreshed it."""
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        wound table until something else refreshed it. The narrow signal
+        (not the coarse character_refreshed) keeps the rest of the sheet
+        from re-projecting."""
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_health_multiplier(3)
         self.assertEqual(1, len(events))
 
     def test_setter_no_op_does_not_emit(self):
         pc = api.character.model()
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_health_multiplier(pc.health_multiplier)
         self.assertEqual(0, len(events))
 
@@ -343,13 +345,13 @@ class TestWoundsSetters(unittest.TestCase):
         api.character.set_wounds_taken("9")
         self.assertEqual(9, api.character.get_wounds_taken())
 
-    def test_set_emits_character_refreshed_on_change(self):
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+    def test_set_emits_wounds_changed_on_change(self):
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_wounds_taken(4)
         self.assertEqual(1, len(events))
 
     def test_set_no_op_does_not_emit(self):
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.set_wounds_taken(0)   # already 0
         self.assertEqual(0, len(events))
 
@@ -379,7 +381,7 @@ class TestWoundsSetters(unittest.TestCase):
         pc = api.character.model()
         pc.wounds = 5
         pc.unsaved = False
-        events = _record_signal(self, api.signals.bus().character_refreshed)
+        events = _record_signal(self, api.signals.bus().wounds_changed)
         api.character.damage_health(0)
         self.assertEqual(5, pc.wounds)
         self.assertFalse(pc.unsaved)

--- a/l5r/qmlui/proxies/app_controller.py
+++ b/l5r/qmlui/proxies/app_controller.py
@@ -855,6 +855,14 @@ class AppController(QObject):
         setter(float(value))
 
     # --- health ------------------------------------------------------
+    #
+    # The api setters below (set_health_multiplier / set_wounds_taken)
+    # already emit character_refreshed when the value actually changes --
+    # see the CLAUDE.md "setters own the dirty flag" contract. We must NOT
+    # call notify_character_refreshed() again here: doing so doubles the
+    # whole-sheet re-projection (every weapon's attack/damage roll, each
+    # rebuilding the datapack modifier set) on every wounds +/- click,
+    # which is what made the wounds stepper feel like it was looping.
 
     @Slot(int)
     def setHealthMultiplier(self, value):
@@ -862,23 +870,18 @@ class AppController(QObject):
             api.character.set_health_multiplier(int(value))
         except ValueError:
             log.api.warning(u"QML UI: invalid health multiplier %r", value)
-            return
-        api.character.notify_character_refreshed()
 
     @Slot(int)
     def damageHealth(self, delta):
         api.character.damage_health(int(delta))
-        api.character.notify_character_refreshed()
 
     @Slot(int)
     def setWoundsTotal(self, value):
         api.character.set_wounds_taken(int(value))
-        api.character.notify_character_refreshed()
 
     @Slot()
     def resetWounds(self):
         api.character.set_wounds_taken(0)
-        api.character.notify_character_refreshed()
 
     # --- skills ------------------------------------------------------
 

--- a/l5r/qmlui/proxies/pc/advancements.py
+++ b/l5r/qmlui/proxies/pc/advancements.py
@@ -16,6 +16,8 @@ from qtpy.QtCore import Property, Signal
 import l5r.api as api
 import l5r.api.character
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 class AdvancementsMixin:
     advancementsChanged = Signal()
@@ -25,12 +27,15 @@ class AdvancementsMixin:
         bus.model_replaced.connect(self._on_model_replaced_advancements)
 
     def _on_character_refreshed_advancements(self):
+        invalidate(self, "advancements")
         self.advancementsChanged.emit()
 
     def _on_model_replaced_advancements(self):
+        invalidate(self, "advancements")
         self.advancementsChanged.emit()
 
     @Property("QVariantList", notify=advancementsChanged)
+    @memoize
     def advancements(self):
         pc = api.character.model()
         if not pc or not pc.advans:

--- a/l5r/qmlui/proxies/pc/combat.py
+++ b/l5r/qmlui/proxies/pc/combat.py
@@ -38,6 +38,9 @@ class CombatMixin:
     def _wire_combat(self, bus):
         bus.character_refreshed.connect(self._on_character_refreshed_combat)
         bus.model_replaced.connect(self._on_model_replaced_combat)
+        # Wounds / health-multiplier changes use a narrow signal so a
+        # wounds +/- click refreshes only this slice, not the whole sheet.
+        bus.wounds_changed.connect(self._on_character_refreshed_combat)
 
     def _on_character_refreshed_combat(self):
         self.combatChanged.emit()

--- a/l5r/qmlui/proxies/pc/combat.py
+++ b/l5r/qmlui/proxies/pc/combat.py
@@ -12,6 +12,8 @@ import l5r.api as api
 import l5r.api.character
 import l5r.api.rules
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 def _wound_label(idx, name):
     """Friendly label string for one row of the wound table. Mirrors
@@ -43,12 +45,15 @@ class CombatMixin:
         bus.wounds_changed.connect(self._on_character_refreshed_combat)
 
     def _on_character_refreshed_combat(self):
+        invalidate(self, "initiative", "armorTn", "wounds")
         self.combatChanged.emit()
 
     def _on_model_replaced_combat(self):
+        invalidate(self, "initiative", "armorTn", "wounds")
         self.combatChanged.emit()
 
     @Property("QVariantMap", notify=combatChanged)
+    @memoize
     def initiative(self):
         pc = api.character.model()
         if not pc:
@@ -60,6 +65,7 @@ class CombatMixin:
         }
 
     @Property("QVariantMap", notify=combatChanged)
+    @memoize
     def armorTn(self):
         pc = api.character.model()
         if not pc:
@@ -76,6 +82,7 @@ class CombatMixin:
         }
 
     @Property("QVariantList", notify=combatChanged)
+    @memoize
     def wounds(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/flags.py
+++ b/l5r/qmlui/proxies/pc/flags.py
@@ -11,6 +11,8 @@ from qtpy.QtCore import Property, Signal
 import l5r.api as api
 import l5r.api.character
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 class FlagsMixin:
     flagsChanged = Signal()
@@ -20,12 +22,15 @@ class FlagsMixin:
         bus.model_replaced.connect(self._on_model_replaced_flags)
 
     def _on_character_refreshed_flags(self):
+        invalidate(self, "flags")
         self.flagsChanged.emit()
 
     def _on_model_replaced_flags(self):
+        invalidate(self, "flags")
         self.flagsChanged.emit()
 
     @Property("QVariantMap", notify=flagsChanged)
+    @memoize
     def flags(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/identity.py
+++ b/l5r/qmlui/proxies/pc/identity.py
@@ -15,6 +15,7 @@ import l5r.api.data
 import l5r.api.data.schools
 
 from l5r.l5rcmcore import APP_DESC, APP_VERSION
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
 
 
 class IdentityMixin:
@@ -40,6 +41,7 @@ class IdentityMixin:
     def _on_family_changed(self, _value):
         self.familyChanged.emit()
         # Family change recomputes school context-relative bits too.
+        invalidate(self, "progression")
         self.progressionChanged.emit()
 
     def _on_clan_changed(self, _value):
@@ -51,6 +53,7 @@ class IdentityMixin:
 
     def _on_character_refreshed_identity(self):
         self.schoolChanged.emit()
+        invalidate(self, "progression")
         self.progressionChanged.emit()
 
     def _on_model_replaced_identity(self):
@@ -58,6 +61,7 @@ class IdentityMixin:
         self.familyChanged.emit()
         self.clanChanged.emit()
         self.schoolChanged.emit()
+        invalidate(self, "progression")
         self.progressionChanged.emit()
         self.displayTitleChanged.emit()
 
@@ -93,6 +97,7 @@ class IdentityMixin:
         return school_.name if school_ else ""
 
     @Property("QVariantMap", notify=progressionChanged)
+    @memoize
     def progression(self):
         return {
             "insight": api.character.insight(),

--- a/l5r/qmlui/proxies/pc/kata.py
+++ b/l5r/qmlui/proxies/pc/kata.py
@@ -29,6 +29,7 @@ import l5r.api.character
 import l5r.api.data
 import l5r.api.data.powers
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
 from l5r.util import log
 
 
@@ -40,12 +41,15 @@ class KataMixin:
         bus.model_replaced.connect(self._on_model_replaced_kata)
 
     def _on_character_refreshed_kata(self):
+        invalidate(self, "kata")
         self.kataChanged.emit()
 
     def _on_model_replaced_kata(self):
+        invalidate(self, "kata")
         self.kataChanged.emit()
 
     @Property("QVariantList", notify=kataChanged)
+    @memoize
     def kata(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/kiho.py
+++ b/l5r/qmlui/proxies/pc/kiho.py
@@ -39,6 +39,8 @@ import l5r.api.character
 import l5r.api.data
 import l5r.api.data.powers
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 class KihoMixin:
     kihoChanged = Signal()
@@ -48,12 +50,15 @@ class KihoMixin:
         bus.model_replaced.connect(self._on_model_replaced_kiho)
 
     def _on_character_refreshed_kiho(self):
+        invalidate(self, "kiho")
         self.kihoChanged.emit()
 
     def _on_model_replaced_kiho(self):
+        invalidate(self, "kiho")
         self.kihoChanged.emit()
 
     @Property("QVariantList", notify=kihoChanged)
+    @memoize
     def kiho(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/memo.py
+++ b/l5r/qmlui/proxies/pc/memo.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2014-2026 Daniele Simonetti
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Memoization for PcProxy slice projections.
+#
+# QML reads a QVariantList / QVariantMap property through a live value
+# wrapper, not a detached JS copy: every element access on the QML side
+# (`xs.length`, `xs[i]`, `m.key`) re-invokes the Python getter. A section
+# that loops over a projection therefore pays O(N) getter calls per
+# refresh -- and without a cache each call rebuilds the projection from
+# the advancement history, turning one purchase into an O(N^2) walk
+# (root cause of the "seconds per advancement" freeze, 2026-06-11).
+#
+# The deal: getters serve a per-instance cached projection; the slice
+# drops the cache right before emitting its notify signal, so QML never
+# observes a stale value.
+
+import functools
+
+
+def memoize(fn):
+    """Serve the projection built by ``fn`` from a per-instance cache.
+
+    Stack between ``@Property`` and the getter::
+
+        @Property("QVariantList", notify=thingsChanged)
+        @memoize
+        def things(self): ...
+
+    Pair every ``thingsChanged.emit()`` with ``invalidate(self, "things")``
+    in the emitting handler. Getters must return a non-None value ([] / {}
+    sentinels are fine and are cached too -- any state change that could
+    alter them also fires the notify signal, which invalidates).
+    """
+    slot = "_memo_" + fn.__name__
+
+    @functools.wraps(fn)
+    def wrapper(self):
+        value = getattr(self, slot, None)
+        if value is None:
+            value = fn(self)
+            setattr(self, slot, value)
+        return value
+
+    return wrapper
+
+
+def invalidate(obj, *names):
+    """Drop the cached projections for ``names`` (getter function names)."""
+    for name in names:
+        setattr(obj, "_memo_" + name, None)

--- a/l5r/qmlui/proxies/pc/misc.py
+++ b/l5r/qmlui/proxies/pc/misc.py
@@ -42,6 +42,8 @@ import l5r.api.character
 import l5r.api.rules
 import l5r.api.rules.modifiers
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 def _pretty_source(slug):
     """Human-ish label for a datapack record slug used as a fallback name."""
@@ -56,12 +58,15 @@ class MiscMixin:
         bus.model_replaced.connect(self._on_model_replaced_misc)
 
     def _on_character_refreshed_misc(self):
+        invalidate(self, "modifiers", "equipment", "money")
         self.miscChanged.emit()
 
     def _on_model_replaced_misc(self):
+        invalidate(self, "modifiers", "equipment", "money")
         self.miscChanged.emit()
 
     @Property("QVariantList", notify=miscChanged)
+    @memoize
     def modifiers(self):
         pc = api.character.model()
         if not pc:
@@ -100,6 +105,7 @@ class MiscMixin:
         return rows
 
     @Property("QVariantList", notify=miscChanged)
+    @memoize
     def equipment(self):
         pc = api.character.model()
         if not pc:
@@ -114,6 +120,7 @@ class MiscMixin:
         return rows
 
     @Property("QVariantMap", notify=miscChanged)
+    @memoize
     def money(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/notes.py
+++ b/l5r/qmlui/proxies/pc/notes.py
@@ -9,6 +9,8 @@ from qtpy.QtCore import Property, Signal
 import l5r.api as api
 import l5r.api.character
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 class NotesMixin:
     notesChanged = Signal()
@@ -23,10 +25,12 @@ class NotesMixin:
         self.notesChanged.emit()
 
     def _on_personal_info_changed(self):
+        invalidate(self, "personalInfo")
         self.personalInfoChanged.emit()
 
     def _on_model_replaced_notes(self):
         self.notesChanged.emit()
+        invalidate(self, "personalInfo")
         self.personalInfoChanged.emit()
 
     @Property(str, notify=notesChanged)
@@ -34,6 +38,7 @@ class NotesMixin:
         return api.character.get_notes()
 
     @Property("QVariantMap", notify=personalInfoChanged)
+    @memoize
     def personalInfo(self):
         return {k: api.character.get_personal_info(k)
                 for k in api.character.personal_info_keys()}

--- a/l5r/qmlui/proxies/pc/opportunities.py
+++ b/l5r/qmlui/proxies/pc/opportunities.py
@@ -37,6 +37,7 @@ import l5r.api as api
 import l5r.api.character
 import l5r.api.character.rankadv
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
 from l5r.util import log
 
 
@@ -153,9 +154,11 @@ class OpportunitiesMixin:
         bus.model_replaced.connect(self._on_opportunities_changed)
 
     def _on_opportunities_changed(self):
+        invalidate(self, "opportunityBadges")
         self.opportunitiesChanged.emit()
 
     @Property("QVariantMap", notify=opportunitiesChanged)
+    @memoize
     def opportunityBadges(self):
         return surfaced_opportunities()
 

--- a/l5r/qmlui/proxies/pc/perks.py
+++ b/l5r/qmlui/proxies/pc/perks.py
@@ -23,6 +23,8 @@ import l5r.api.character.rankadv
 import l5r.api.data.flaws
 import l5r.api.data.merits
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 # 4e RAW caps disadvantage XP at 10. The app does not enforce it -- the
 # cap is surfaced cosmetically in the section so the player can see the
@@ -130,18 +132,22 @@ class PerksMixin:
         bus.model_replaced.connect(self._on_model_replaced_perks)
 
     def _on_character_refreshed_perks(self):
+        invalidate(self, "merits", "flaws")
         self.perksChanged.emit()
 
     def _on_model_replaced_perks(self):
+        invalidate(self, "merits", "flaws")
         self.perksChanged.emit()
 
     # ----- live registers ------------------------------------------
 
     @Property("QVariantList", notify=perksChanged)
+    @memoize
     def merits(self):
         return self._collect("merit")
 
     @Property("QVariantList", notify=perksChanged)
+    @memoize
     def flaws(self):
         return self._collect("flaw")
 

--- a/l5r/qmlui/proxies/pc/skills.py
+++ b/l5r/qmlui/proxies/pc/skills.py
@@ -19,6 +19,8 @@ import l5r.api.rules
 
 import l5r.models.chmodel as chmodel
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 # Attribute -> ring key map. The api side keeps trait_id -> ring lookup
 # in l5r.api.data.get_trait_ring(), but that returns the localised ring
@@ -53,12 +55,15 @@ class SkillsMixin:
         bus.model_replaced.connect(self._on_model_replaced_skills)
 
     def _on_character_refreshed_skills(self):
+        invalidate(self, "skills")
         self.skillsChanged.emit()
 
     def _on_model_replaced_skills(self):
+        invalidate(self, "skills")
         self.skillsChanged.emit()
 
     @Property("QVariantList", notify=skillsChanged)
+    @memoize
     def skills(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/spells.py
+++ b/l5r/qmlui/proxies/pc/spells.py
@@ -58,6 +58,7 @@ import l5r.api.character.spells
 import l5r.api.data
 import l5r.api.data.spells
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
 from l5r.util import log
 
 
@@ -120,12 +121,15 @@ class SpellsMixin:
         bus.model_replaced.connect(self._on_model_replaced_spells)
 
     def _on_character_refreshed_spells(self):
+        invalidate(self, "spells", "spellAffinities", "spellDeficiencies")
         self.spellsChanged.emit()
 
     def _on_model_replaced_spells(self):
+        invalidate(self, "spells", "spellAffinities", "spellDeficiencies")
         self.spellsChanged.emit()
 
     @Property("QVariantList", notify=spellsChanged)
+    @memoize
     def spells(self):
         pc = api.character.model()
         if not pc:
@@ -196,6 +200,7 @@ class SpellsMixin:
         return rows
 
     @Property("QVariantList", notify=spellsChanged)
+    @memoize
     def spellAffinities(self):
         """Localised elemental affinities granted by the character's
         school(s). Empty list when the character has none."""
@@ -209,6 +214,7 @@ class SpellsMixin:
             return []
 
     @Property("QVariantList", notify=spellsChanged)
+    @memoize
     def spellDeficiencies(self):
         """Localised elemental deficiencies. Empty list when none."""
         if not api.character.model():

--- a/l5r/qmlui/proxies/pc/tattoo.py
+++ b/l5r/qmlui/proxies/pc/tattoo.py
@@ -34,6 +34,8 @@ import l5r.api.character
 import l5r.api.data
 import l5r.api.data.powers
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 class TattooMixin:
     tattooChanged = Signal()
@@ -43,12 +45,15 @@ class TattooMixin:
         bus.model_replaced.connect(self._on_model_replaced_tattoo)
 
     def _on_character_refreshed_tattoo(self):
+        invalidate(self, "tattoo")
         self.tattooChanged.emit()
 
     def _on_model_replaced_tattoo(self):
+        invalidate(self, "tattoo")
         self.tattooChanged.emit()
 
     @Property("QVariantList", notify=tattooChanged)
+    @memoize
     def tattoo(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/techniques.py
+++ b/l5r/qmlui/proxies/pc/techniques.py
@@ -28,6 +28,7 @@ import l5r.api.character.schools
 import l5r.api.data
 import l5r.api.data.schools
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
 from l5r.util import log
 
 
@@ -44,12 +45,15 @@ class TechniquesMixin:
         bus.model_replaced.connect(self._on_model_replaced_techniques)
 
     def _on_character_refreshed_techniques(self):
+        invalidate(self, "techniques")
         self.techniquesChanged.emit()
 
     def _on_model_replaced_techniques(self):
+        invalidate(self, "techniques")
         self.techniquesChanged.emit()
 
     @Property("QVariantList", notify=techniquesChanged)
+    @memoize
     def techniques(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/traits.py
+++ b/l5r/qmlui/proxies/pc/traits.py
@@ -14,6 +14,8 @@ import l5r.api.data
 
 import l5r.models as models
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
+
 
 class TraitsMixin:
     traitsChanged = Signal()
@@ -23,12 +25,15 @@ class TraitsMixin:
         bus.model_replaced.connect(self._on_model_replaced_traits)
 
     def _on_character_refreshed_traits(self):
+        invalidate(self, "rings", "attribs")
         self.traitsChanged.emit()
 
     def _on_model_replaced_traits(self):
+        invalidate(self, "rings", "attribs")
         self.traitsChanged.emit()
 
     @Property("QVariantMap", notify=traitsChanged)
+    @memoize
     def rings(self):
         pc = api.character.model()
         if not pc:
@@ -36,6 +41,7 @@ class TraitsMixin:
         return {r: api.character.ring_rank(r) for r in models.chmodel.RINGS._ids}
 
     @Property("QVariantMap", notify=traitsChanged)
+    @memoize
     def attribs(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/proxies/pc/weapons.py
+++ b/l5r/qmlui/proxies/pc/weapons.py
@@ -50,6 +50,7 @@ import l5r.api.character
 import l5r.api.character.weapons
 import l5r.api.rules
 
+from l5r.qmlui.proxies.pc.memo import invalidate, memoize
 from l5r.util import log
 
 # The three combat categories, in reading order. A weapon shows on every
@@ -79,12 +80,15 @@ class WeaponsMixin:
         bus.model_replaced.connect(self._on_model_replaced_weapons)
 
     def _on_character_refreshed_weapons(self):
+        invalidate(self, "weapons", "armor")
         self.weaponsChanged.emit()
 
     def _on_model_replaced_weapons(self):
+        invalidate(self, "weapons", "armor")
         self.weaponsChanged.emit()
 
     @Property("QVariantList", notify=weaponsChanged)
+    @memoize
     def weapons(self):
         pc = api.character.model()
         if not pc:
@@ -132,6 +136,7 @@ class WeaponsMixin:
         return rows
 
     @Property("QVariantMap", notify=weaponsChanged)
+    @memoize
     def armor(self):
         pc = api.character.model()
         if not pc:

--- a/l5r/qmlui/qml/Theme/Theme.qml
+++ b/l5r/qmlui/qml/Theme/Theme.qml
@@ -100,6 +100,10 @@ QtObject {
     // 14px with a 4px gap).
     readonly property int pointDotSize: 14
     readonly property int pointDotSpacing: 4
+    // Tenth-digit rendered inside each dot on the social tracks
+    // (design §6.12: the digit spells out that dots are tenths of a
+    // rank). Sized to sit inside the 14px dot with breathing room.
+    readonly property int pointDotDigitSize: 9
 
     // --- font families (design system §3.1) ------------------------
     // Each face is bundled in l5r/share/fonts/ and registered at qmlui

--- a/l5r/qmlui/qml/sections/CharacterSection.qml
+++ b/l5r/qmlui/qml/sections/CharacterSection.qml
@@ -445,10 +445,11 @@ ColumnLayout {
             // they're almost always zero in play and don't deserve the
             // same prominence.
             // Click dot sets value, shift+click bumps rank (resets
-            // points), scroll fine-tunes by 1. Shift+click and clicking
-            // the 10th dot both route through setFlag(rank+1) -- when
-            // the model pushes back the value binding resets the dots
-            // to 0 naturally.
+            // points), scroll fine-tunes by 0.1 and ROLLS OVER at the
+            // rank boundary (5.9 -> 6.0, 6.0 -> 5.9; issue #402). The
+            // dots carry their tenth digit and the combined N.N score
+            // sits big at the left of each track so the rank/decimal
+            // split reads at a glance.
             // -------------------------------------------------------------
             Label {
                 Layout.fillWidth: true
@@ -471,7 +472,7 @@ ColumnLayout {
             Label {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignRight
-                text: qsTr("click dot to set · shift+click to advance rank · scroll to fine-tune")
+                text: qsTr("dots are tenths of a rank · click dot to set · scroll to fine-tune (rolls over) · shift+click to advance rank")
                 font.italic: true
                 font.pixelSize: Theme.fsCaption
                 opacity: 0.6
@@ -515,6 +516,16 @@ ColumnLayout {
                         if (_flagRank < 10)
                             appCtrl.setFlag(_key, _flagRank + 1);
                     }
+                    // Wheel roll-over past the track ends (issue #402):
+                    // up from N.9 lands on (N+1).0, down from N.0 on (N-1).9.
+                    function _wrapRank(direction) {
+                        if (!appCtrl)
+                            return;
+                        if (direction > 0 && _flagRank < 10)
+                            appCtrl.setFlag(_key, _flagRank + 1);
+                        else if (direction < 0 && _flagRank > 0)
+                            appCtrl.setFlag(_key, (_flagRank - 1) + 0.9);
+                    }
 
                     RowLayout {
                         Layout.fillWidth: true
@@ -546,23 +557,40 @@ ColumnLayout {
                         Item {
                             Layout.fillWidth: true
                         }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: 20  // align under the label
+                        spacing: 10
                         Label {
-                            text: qsTr("rank ") + _flagRank + "." + _flagPoints
-                            font.pixelSize: Theme.fsCaption
+                            // The actual score, rank.tenths -- the number
+                            // the table reads. Stat-sized so it doesn't
+                            // fade into the parchment (issue #402).
+                            text: _flagRank + "." + _flagPoints
+                            font.family: Theme.fontStat
+                            font.pixelSize: Theme.fsStatMedium
+                            font.weight: Theme.wMedium
                             font.features: Theme.tabularNumbers
                             color: _flagColor
-                            opacity: 0.9
                         }
-                    }
-                    Widgets.PointTrack {
-                        Layout.leftMargin: 20  // align under the label
-                        count: 9  // points 0..9 within a rank; no roll-over
-                        value: _flagPoints
-                        accent: _flagColor
-                        onValueRequested: function (v) {
-                            _commitPoints(v);
+                        Widgets.PointTrack {
+                            Layout.alignment: Qt.AlignVCenter
+                            count: 9  // tenths 1..9; wheel rolls the rank over
+                            value: _flagPoints
+                            accent: _flagColor
+                            showDigits: true
+                            wrap: true
+                            onValueRequested: function (v) {
+                                _commitPoints(v);
+                            }
+                            onRankBumpRequested: _bumpRank()
+                            onWrapRequested: function (direction) {
+                                _wrapRank(direction);
+                            }
                         }
-                        onRankBumpRequested: _bumpRank()
+                        Item {
+                            Layout.fillWidth: true
+                        }
                     }
                 }
             }
@@ -625,36 +653,53 @@ ColumnLayout {
                                 Layout.fillWidth: true
                                 elide: Text.ElideRight
                             }
+                        }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
                             Label {
                                 text: _flagRank + "." + _flagPoints
-                                font.pixelSize: Theme.fsCaption
+                                font.family: Theme.fontStat
+                                font.pixelSize: Theme.fsStatSmall
                                 font.features: Theme.tabularNumbers
                                 color: _flagColor
-                                opacity: 0.9
                             }
-                        }
-                        Widgets.PointTrack {
-                            count: 9  // points 0..9 within a rank; no roll-over
-                            dotSize: 10
-                            value: _flagPoints
-                            accent: _flagColor
-                            onValueRequested: function (v) {
-                                if (!appCtrl)
-                                    return;
-                                // Points 0..9 only; dots never roll the rank
-                                // over (shift+click or the stepper does that).
-                                var pts = Math.max(0, Math.min(9, v));
-                                var combined = _flagRank + pts / 10.0;
-                                if (Math.abs(combined - _flagValue) > 0.001) {
-                                    appCtrl.setFlag(_key, combined);
+                            Widgets.PointTrack {
+                                Layout.alignment: Qt.AlignVCenter
+                                count: 9  // tenths 1..9; wheel rolls the rank over
+                                dotSize: 10
+                                value: _flagPoints
+                                accent: _flagColor
+                                wrap: true
+                                onValueRequested: function (v) {
+                                    if (!appCtrl)
+                                        return;
+                                    // Dots edit the tenths only; the wheel
+                                    // (wrap) or shift+click change the rank.
+                                    var pts = Math.max(0, Math.min(9, v));
+                                    var combined = _flagRank + pts / 10.0;
+                                    if (Math.abs(combined - _flagValue) > 0.001) {
+                                        appCtrl.setFlag(_key, combined);
+                                    }
+                                }
+                                onRankBumpRequested: {
+                                    if (!appCtrl)
+                                        return;
+                                    if (_flagRank < 10) {
+                                        appCtrl.setFlag(_key, _flagRank + 1);
+                                    }
+                                }
+                                onWrapRequested: function (direction) {
+                                    if (!appCtrl)
+                                        return;
+                                    if (direction > 0 && _flagRank < 10)
+                                        appCtrl.setFlag(_key, _flagRank + 1);
+                                    else if (direction < 0 && _flagRank > 0)
+                                        appCtrl.setFlag(_key, (_flagRank - 1) + 0.9);
                                 }
                             }
-                            onRankBumpRequested: {
-                                if (!appCtrl)
-                                    return;
-                                if (_flagRank < 10) {
-                                    appCtrl.setFlag(_key, _flagRank + 1);
-                                }
+                            Item {
+                                Layout.fillWidth: true
                             }
                         }
                     }

--- a/l5r/qmlui/qml/sections/WeaponsSection.qml
+++ b/l5r/qmlui/qml/sections/WeaponsSection.qml
@@ -69,7 +69,11 @@ ColumnLayout {
     // Defensive binding -- proxy may be absent on first paint or under
     // the offscreen preview tool (which binds a null pcProxy).
     // -----------------------------------------------------------------
-    readonly property var _weapons: (pcProxy && pcProxy.weapons) ? pcProxy.weapons : []
+    // Read pcProxy.weapons once: the getter rebuilds the whole list (and
+    // recomputes every weapon's attack/damage roll) on each call, so the
+    // old `(pcProxy && pcProxy.weapons) ? pcProxy.weapons : []` form paid
+    // for it twice per re-projection.
+    readonly property var _weapons: pcProxy ? pcProxy.weapons : []
     readonly property bool _hasWeapons: _weapons.length > 0
 
     // The worn armour (at most one). Earth-toned, heads the rack.

--- a/l5r/qmlui/qml/widgets/PointTrack.qml
+++ b/l5r/qmlui/qml/widgets/PointTrack.qml
@@ -7,7 +7,10 @@
 //                           again to request `index` (matches CkNumWidget).
 //   * shift+click dot    -> emit `rankBumpRequested()` so the parent can
 //                           advance the underlying rank.
-//   * wheel up / down    -> request ±1, clamped to [0, count].
+//   * wheel up / down    -> request ±1, clamped to [0, count]. With
+//                           `wrap: true`, scrolling past either end emits
+//                           `wrapRequested(±1)` instead so the parent can
+//                           roll the rank over (e.g. 5.9 -> 6.0).
 // Like RankStepper, this widget is SIGNAL-ONLY: it emits `valueRequested`
 // and never assigns its own `value`. The parent owns `value` via a binding
 // to the model, so the dots always track live model state. (Self-assigning
@@ -19,6 +22,9 @@
 // the honor track in green, infamy in red, void in purple). `dotSize`
 // is parametric so compact contexts (Shadowlands/Infamy on the social
 // panel) can ship a smaller variant without forking the widget.
+// `showDigits` prints each dot's value (1..count) inside the dot --
+// the social tracks use it to spell out that the dots are the tenths
+// of the rank (design §6.12, issue #402).
 import QtQuick
 import QtQuick.Layouts
 import Theme 1.0
@@ -29,7 +35,12 @@ Row {
     property int value: 0
     property int dotSize: Theme.pointDotSize
     property color accent: Theme.accent
+    property bool showDigits: false
+    // When true, wheel-scrolling past either end emits wrapRequested
+    // instead of clamping, so the parent can roll an adjacent rank.
+    property bool wrap: false
     signal rankBumpRequested
+    signal wrapRequested(int direction)
     // Emitted on user interaction with the requested new value. The widget
     // does NOT assign `value` itself -- the parent commits to the model and
     // the `value` binding flows the result back (see header note).
@@ -42,9 +53,14 @@ Row {
         acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
         onWheel: function (event) {
             var step = event.angleDelta.y > 0 ? 1 : -1;
-            var newValue = Math.max(0, Math.min(track.count, track.value + step));
-            if (newValue !== track.value) {
-                track.valueRequested(newValue);
+            var newValue = track.value + step;
+            if (track.wrap && (newValue > track.count || newValue < 0)) {
+                track.wrapRequested(step);
+            } else {
+                newValue = Math.max(0, Math.min(track.count, newValue));
+                if (newValue !== track.value) {
+                    track.valueRequested(newValue);
+                }
             }
             event.accepted = true;
         }
@@ -67,6 +83,18 @@ Row {
                 NumberAnimation {
                     duration: 90
                 }
+            }
+
+            // The dot's own value (1..count) printed inside it -- on
+            // the social tracks this reads as ".1 .2 .3", making it
+            // explicit that the dots are the tenths of the rank.
+            Text {
+                visible: track.showDigits
+                anchors.centerIn: parent
+                text: index + 1
+                font.family: Theme.fontStat
+                font.pixelSize: Theme.pointDotDigitSize
+                color: index < track.value ? Theme.parchment : track.accent
             }
 
             MouseArea {

--- a/l5r/util/log.py
+++ b/l5r/util/log.py
@@ -33,7 +33,7 @@ def log_setup(base_path, base_name):
     root = logging.getLogger('')
 
     # set the level of the root logger
-    root.setLevel(logging.DEBUG)
+    root.setLevel(logging.INFO)
 
     # define the file formatter
     file_fmt = logging.Formatter('%(asctime)s %(name)-12s ' +


### PR DESCRIPTION
  Three fixes for the QML sheet, two performance and one UX. Closes #402, closes #419.

  ## 1. Wounds +/- no longer re-projects the whole sheet (#419)

  Clicking the wounds stepper emitted the coarse `character_refreshed`, making every
  PcProxy slice re-emit — the weapons slice alone recomputed every attack/damage roll
  per click. Wounds and health-multiplier changes now go through a narrow
  `wounds_changed` bus signal that only the combat slice listens to. Also drops a
  redundant `notify_character_refreshed()` from the health controller slots (the api
  setters already emit), demotes the per-weapon `calc base atk` log to DEBUG, and
  reads `pcProxy.weapons` once in WeaponsSection.

  ## 2. Memoized PcProxy slice projections 

  Root cause of the "every advancement takes seconds" freeze. QML reads a
  `QVariantList`/`QVariantMap` property through a **live value wrapper**, not a
  detached JS copy: every element access on the QML side (`xs.length`, `xs[i]`,
  `m.key`) re-invokes the Python getter. A section looping over a projection pays
  O(N) getter calls per refresh — SkillsSection alone makes 4N+5 reads per
  `skillsChanged` — and each call rebuilt the projection from the advancement
  history, turning one purchase into an O(N²) walk that grows with the character.

  (The regression surfaced with autosave/resume only because launch now restores the
  real character instead of a blank one — the cost itself predates it.)

  Fix: new `proxies/pc/memo.py` with a `@memoize` decorator stacked under
  `@Property`, serving a per-instance cached projection; `invalidate()` runs right
  before every notify emit, so QML never observes a stale value. Applied to every
  `QVariantList`/`QVariantMap` getter across all 16 slice mixins.

  Measured offscreen on a real character (35 advancements):

  | | before | after |
  |---|---|---|
  | buy skill rank | 1.25–1.48 s | **0.08 s** |
  | engine load | 1.93 s | 0.88 s |

  The two perf fixes are complementary: the narrow signal avoids invalidating slices
  whose data didn't change (and the Repeater teardown that re-emitting causes), the
  memo makes the slices that *are* touched free to re-read.

  **Invariant to preserve:** every emit of a memoized property's notify signal must
  be preceded by `invalidate(self, ...)` in the emitting handler.

  ## 3. Social flag tracks read as rank-tenths (#402)

  Honor/Glory/Status track UX, as suggested in the issue: each dot carries its tenth
  digit (1..9); the wheel wraps the rank at track ends (up from 5.9 → 6.0, down from
  6.0 → 5.9, also on the compact Taint/Infamy tracks); the combined N.N score becomes
  a 20px EB Garamond figure left of the dots. New Theme token `pointDotDigitSize`,
  design system §6.12 updated.

  ## Test plan

  - `python -m unittest discover -s l5r` — 128 tests OK
  - `flake8` (CI selectors) clean
  - Manually exercised advancement purchases, wounds stepper and flag tracks in the
    QML UI with a real character

Closes #402, closes #419, closes #421

  🤖 Generated with [Claude Code](https://claude.com/claude-code)