### PR TITLE
feat(ui): add "+" button to award experience points (#404)

### DIFF
--- a/l5r/main.py
+++ b/l5r/main.py
@@ -255,6 +255,7 @@ class L5RMain(AboutTabMixin, AdvancementsTabMixin, AdvanceMixin, AdviseMixin,
         self.bt_edit_school.clicked.connect(self.pc_info_sink.on_edit_first_school)
 
         self.bt_set_exp_points.clicked.connect(self.pc_info_sink.on_set_exp_limit)
+        self.bt_add_exp_points.clicked.connect(self.pc_info_sink.on_add_exp_points)
 
     def closeEvent(self, ev):
         # update interface last time, to set unsaved states

--- a/l5r/qmlui/qml/sections/CharacterSection.qml
+++ b/l5r/qmlui/qml/sections/CharacterSection.qml
@@ -297,6 +297,12 @@ ColumnLayout {
                 ToolTip.text: qsTr("Edit XP limit")
                 onClicked: expLimitDlg.openWithCurrent()
             }
+            ToolButton {
+                text: "+"
+                ToolTip.visible: hovered
+                ToolTip.text: qsTr("Add awarded XP")
+                onClicked: addXpDlg.openFresh()
+            }
         }
 
         RowLayout {
@@ -974,6 +980,49 @@ ColumnLayout {
                 id: xpSpin
                 Layout.fillWidth: true
                 from: 0
+                to: 10000
+                editable: true
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Award-XP prompt -- adds the award on top of the current limit so
+    // the user never has to do the math themselves (issue #404).
+    // -----------------------------------------------------------------
+    Widgets.L5RDialog {
+        id: addXpDlg
+        width: 380
+        padding: Theme.s5
+        title: qsTr("Add Experience Points")
+        tagline: qsTr("the chronicle rewards its heroes")
+        seal: "賞"   // shou -- award
+        accent: Theme.secondary
+        accentDark: Theme.secondaryDark
+        acceptText: qsTr("Add")
+
+        function openFresh() {
+            awardSpin.value = 1;
+            open();
+        }
+        onAccepted: if (appCtrl)
+            appCtrl.setExpLimit(section._prog.rawXpLimit + awardSpin.value)
+
+        contentItem: RowLayout {
+            spacing: 12
+            Label {
+                text: qsTr("XP awarded")
+                font.family: Theme.fontDisplay
+                font.pixelSize: Theme.fsCaption
+                font.weight: Theme.headingWeight
+                font.letterSpacing: 1.6
+                color: Theme.heading
+                Layout.alignment: Qt.AlignVCenter
+            }
+            SpinBox {
+                id: awardSpin
+                Layout.fillWidth: true
+                from: 1
                 to: 10000
                 editable: true
             }

--- a/l5r/ui/tabs/pc_info.py
+++ b/l5r/ui/tabs/pc_info.py
@@ -57,6 +57,15 @@ class PcInfoSink(QtCore.QObject):
         if ok:
             window.set_exp_limit(val)
 
+    def on_add_exp_points(self):
+        window = self.window
+
+        val, ok = QtWidgets.QInputDialog.getInt(window, 'Add Experience Points',
+                                                "XP awarded:", 1,
+                                                1, 10000, 1)
+        if ok:
+            window.set_exp_limit(window.pc.exp_limit + val)
+
     def on_edit_family(self):
         window = self.window
         dlg = widgets.FamilyChooserDialog(window)
@@ -162,14 +171,20 @@ class PcInfoTabMixin:
             bt_exp.setToolTip(self.tr("Edit experience points"))
             bt_exp.setAutoRaise(True)
             bt_exp.setIcon(QtGui.QIcon(get_icon_path('edit', (16, 16))))
+            bt_add_exp = QtWidgets.QToolButton(self)
+            bt_add_exp.setToolTip(self.tr("Add experience points"))
+            bt_add_exp.setAutoRaise(True)
+            bt_add_exp.setIcon(QtGui.QIcon(get_icon_path('add', (16, 16))))
             hb_exp.addWidget(lb_exp)
             hb_exp.addWidget(bt_exp)
+            hb_exp.addWidget(bt_add_exp)
 
             grid.addWidget(QtWidgets.QLabel(self.tr("Rank"), self), 0, 3)
             grid.addWidget(fr_exp, 1, 3)
             grid.addWidget(QtWidgets.QLabel(self.tr("Insight"), self), 2, 3)
 
             self.bt_set_exp_points = bt_exp
+            self.bt_add_exp_points = bt_add_exp
 
             # 2nd column
             grid.addWidget(self.tx_pc_name, 0, 1, 1, 2)


### PR DESCRIPTION
## Summary
Implements #404: next to the existing edit-XP pencil there is now a "+" button that asks for the **awarded** XP amount and raises the XP limit by that amount, so the user no longer has to do the math themselves.

Implemented in both UIs:
- **Legacy (QWidget)**: new `QToolButton` (16x16 `add.png`) in the Exp. Points header, with `PcInfoSink.on_add_exp_points` prompting "XP awarded:" via `QInputDialog` (min 1).
- **QML (4.0)**: new "+" `ToolButton` in the XP row of `CharacterSection.qml`, opening an `addXpDlg` (`L5RDialog`, seal 賞, same shape/accent as the existing `expLimitDlg`).

Both paths delegate to the canonical `api.character.set_exp_limit`, which already owns the dirty flag and emits `character_refreshed`, so insight/rank recalculation and unsaved-changes prompts come for free.

## Notes
- New `qsTr`/`tr` strings are not yet extracted into the `.ts` files; they will be picked up by the next run of `tools/scripts/update_translations.py` (kept out of this PR to avoid churning all translation files).

## Test plan
- `flake8` (CI ruleset) passes on the touched Python files.
- App boots offscreen with the QML UI, no QML load errors.
- Manual: pencil still sets an absolute limit; "+" adds on top of the current limit in both UIs.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)