### PR TITLE
fix(qml): re-evaluate Family/School edit state on character change (#433)

### DIFF
--- a/l5r/qmlui/proxies/pc/identity.py
+++ b/l5r/qmlui/proxies/pc/identity.py
@@ -25,6 +25,7 @@ class IdentityMixin:
     schoolChanged = Signal()
     progressionChanged = Signal()
     displayTitleChanged = Signal()
+    canEditOriginChanged = Signal()
 
     def _wire_identity(self, bus):
         bus.name_changed.connect(self._on_name_changed)
@@ -43,6 +44,7 @@ class IdentityMixin:
         # Family change recomputes school context-relative bits too.
         invalidate(self, "progression")
         self.progressionChanged.emit()
+        self.canEditOriginChanged.emit()
 
     def _on_clan_changed(self, _value):
         self.clanChanged.emit()
@@ -55,6 +57,7 @@ class IdentityMixin:
         self.schoolChanged.emit()
         invalidate(self, "progression")
         self.progressionChanged.emit()
+        self.canEditOriginChanged.emit()
 
     def _on_model_replaced_identity(self):
         self.nameChanged.emit()
@@ -64,6 +67,7 @@ class IdentityMixin:
         invalidate(self, "progression")
         self.progressionChanged.emit()
         self.displayTitleChanged.emit()
+        self.canEditOriginChanged.emit()
 
     @Property(str, notify=nameChanged)
     def name(self):
@@ -95,6 +99,16 @@ class IdentityMixin:
             return ""
         school_ = api.data.schools.get(sid)
         return school_.name if school_ else ""
+
+    @Property(bool, notify=canEditOriginChanged)
+    def canEditOrigin(self):
+        """Origin (family/school) edits are blocked once any advancement
+        has been recorded -- mirrors the QWidget side's disabled edit
+        buttons. Exposed as a NOTIFY property (not a one-shot Slot call)
+        so the Family/School edit icons re-enable/disable when the active
+        character is replaced or refreshed (issue #433)."""
+        pc = api.character.model()
+        return bool(pc and len(pc.advans) == 0)
 
     @Property("QVariantMap", notify=progressionChanged)
     @memoize

--- a/l5r/qmlui/qml/sections/CharacterSection.qml
+++ b/l5r/qmlui/qml/sections/CharacterSection.qml
@@ -42,7 +42,7 @@ ColumnLayout {
             "currentTn": 0,
             "desc": ""
         })
-    readonly property bool _canEditOrigin: appCtrl ? appCtrl.canEditOrigin() : true
+    readonly property bool _canEditOrigin: pcProxy ? pcProxy.canEditOrigin : true
 
     // A pending rank-up (the root opportunity -- every grant flows from
     // it). Drives the callout below; the matching TOC badge comes from the


### PR DESCRIPTION
## Problem

Fixes #433. In the QML (4.0 RC) UI, the Family/School edit icons in the Character section kept the *previously loaded* character's enabled/disabled state. Switching characters via the file menu after autoload, creating a new character, or selecting family/school did not update them.

## Root cause

`CharacterSection.qml` bound the icon state to `appCtrl.canEditOrigin()` — a one-shot `@Slot` **function call**. A QML binding over a function call only re-evaluates when its tracked dependencies change; the only dependency here is `appCtrl`, which is constant for the app lifetime. So the binding never recomputed when the active character changed.

Every other header field avoids this by binding to a `pcProxy` *property* that re-emits on the refresh bus.

## Fix

- `l5r/qmlui/proxies/pc/identity.py`: expose `canEditOrigin` as a NOTIFY property (mirroring the legacy `refresh.py` `len(pc.advans) == 0` check), emitting `canEditOriginChanged` on `family_changed` / `character_refreshed` / `model_replaced`.
- `CharacterSection.qml`: rebind to `pcProxy.canEditOrigin`.

The binding now re-evaluates on `model_replaced` (open/new/switch) and `character_refreshed` (after family/school selection), matching the legacy QWidget behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)