### PR TITLE
fix(win): register each Liberation Sans face under its own name (#426)

### DIFF
--- a/tools/deploy/windows/setup-user.iss
+++ b/tools/deploy/windows/setup-user.iss
@@ -42,9 +42,9 @@ Source: "fonts/OLDSSCH_.TTF"; DestDir: "{userfonts}"; FontInstall: "Oldstyle Sma
 Source: "fonts/OLDSIH__.TTF"; DestDir: "{userfonts}"; FontInstall: "Oldstyle Italic"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontOldStyle
 Source: "fonts/OLDSH___.TTF"; DestDir: "{userfonts}"; FontInstall: "Oldstyle 1"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontOldStyle
 Source: "fonts/LiberationSans-Regular.ttf"; DestDir: "{userfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
-Source: "fonts/LiberationSans-Italic.ttf"; DestDir: "{userfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
-Source: "fonts/LiberationSans-BoldItalic.ttf"; DestDir: "{userfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
-Source: "fonts/LiberationSans-Bold.ttf"; DestDir: "{userfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
+Source: "fonts/LiberationSans-Italic.ttf"; DestDir: "{userfonts}"; FontInstall: "Liberation Sans Italic"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
+Source: "fonts/LiberationSans-BoldItalic.ttf"; DestDir: "{userfonts}"; FontInstall: "Liberation Sans Bold Italic"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
+Source: "fonts/LiberationSans-Bold.ttf"; DestDir: "{userfonts}"; FontInstall: "Liberation Sans Bold"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
 ; core pack
 Source: "core.l5rcmpack"; DestDir: "{app}";
 

--- a/tools/deploy/windows/setup.iss
+++ b/tools/deploy/windows/setup.iss
@@ -41,9 +41,9 @@ Source: "fonts/OLDSSCH_.TTF"; DestDir: "{commonfonts}"; FontInstall: "Oldstyle S
 Source: "fonts/OLDSIH__.TTF"; DestDir: "{commonfonts}"; FontInstall: "Oldstyle Italic"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontOldStyle
 Source: "fonts/OLDSH___.TTF"; DestDir: "{commonfonts}"; FontInstall: "Oldstyle 1"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontOldStyle
 Source: "fonts/LiberationSans-Regular.ttf"; DestDir: "{commonfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
-Source: "fonts/LiberationSans-Italic.ttf"; DestDir: "{commonfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
-Source: "fonts/LiberationSans-BoldItalic.ttf"; DestDir: "{commonfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
-Source: "fonts/LiberationSans-Bold.ttf"; DestDir: "{commonfonts}"; FontInstall: "Liberation Sans"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
+Source: "fonts/LiberationSans-Italic.ttf"; DestDir: "{commonfonts}"; FontInstall: "Liberation Sans Italic"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
+Source: "fonts/LiberationSans-BoldItalic.ttf"; DestDir: "{commonfonts}"; FontInstall: "Liberation Sans Bold Italic"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
+Source: "fonts/LiberationSans-Bold.ttf"; DestDir: "{commonfonts}"; FontInstall: "Liberation Sans Bold"; Flags: onlyifdoesntexist uninsneveruninstall; Tasks: fontLiberations
 ; core pack
 Source: "core.l5rcmpack"; DestDir: "{app}";
 


### PR DESCRIPTION
Fixes #426.

## Problem
Exported PDFs render the skills page as gibberish; Acrobat reports the *Liberation Sans* font is missing. Installing the fonts manually resolves it. The installer claims to install the fonts but only one face actually lands.

## Root cause
In both `tools/deploy/windows/setup.iss` and `setup-user.iss`, all four Liberation Sans TTFs were registered under the identical `FontInstall: "Liberation Sans"`. Windows keys the font registry by that display name, so the four entries clobbered each other and only a single face survived.

## Fix
Give each face its true name (matching the TTF `name` table), verified by reading each file:

| File | `FontInstall` |
|---|---|
| Regular | `Liberation Sans` |
| Italic | `Liberation Sans Italic` |
| Bold | `Liberation Sans Bold` |
| BoldItalic | `Liberation Sans Bold Italic` |

Applied to both the machine-wide (`{commonfonts}`) and per-user (`{userfonts}`) installer scripts.

## Notes
- Only verifiable in a freshly built installer; not testable from the repo directly.
- `onlyifdoesntexist` means users with a stale/broken registry entry from an older installer may still need a manual cleanup, but clean installs are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)