### PR TITLE
feat(qml): batch heal/damage dialog for wounds

### DIFF
--- a/l5r/qmlui/qml/dialogs/DamageHealDialog.qml
+++ b/l5r/qmlui/qml/dialogs/DamageHealDialog.qml
@@ -1,0 +1,173 @@
+// Copyright (C) 2014-2026 Daniele Simonetti
+// DamageHealDialog -- QML-native form for inflicting or healing a batch of
+// wounds at once. Replaces the per-1 +/- stepper that used to sit in the
+// WoundsBlock header: that widget made the player click N times to apply a
+// hit, which does not match how the game actually deals damage (a single
+// roll inflicts many wounds at once). Opened from the WoundsBlock header
+// button:
+//     damageHealDlg.present()             // defaults to "inflict"
+//
+// A two-segment Inflict / Heal selector (default Inflict) flips the mode;
+// the accent follows it -- crimson for damage, green for healing -- so the
+// whole dialog reads at a glance as either harm or mending. The amount is a
+// plain positive integer; on accept it is routed through
+// appCtrl.damageHealth(+/-n) so the dirty flag + narrow wounds_changed
+// signal stay correct (same path as the old stepper).
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Theme 1.0
+
+import "../widgets" as Widgets
+
+Widgets.L5RDialog {
+    id: root
+    width: Math.min(Overlay.overlay ? Overlay.overlay.width - 120 : 420, 420)
+    padding: Theme.s5
+
+    // --- state ----------------------------------------------------
+    // _heal == false  ->  inflict wounds (default)
+    property bool _heal: false
+    readonly property int _amount: parseInt(amountField.text, 10)
+    readonly property bool _valid: !isNaN(_amount) && _amount > 0
+
+    // Current / max wounds for the live preview of the resulting total.
+    readonly property int _cur: pcProxy ? pcProxy.currentWounds : 0
+    readonly property int _max: pcProxy ? pcProxy.maxWounds : 0
+    readonly property int _result: {
+        if (!_valid)
+            return _cur;
+        var n = _heal ? _cur - _amount : _cur + _amount;
+        return Math.max(0, Math.min(n, _max));
+    }
+
+    // --- chrome (via L5RDialog) -----------------------------------
+    // The accent (and seal) follow the mode: crimson 傷 (wound) for inflict,
+    // green 治 (heal) for mending.
+    readonly property color _accent: _heal ? Theme.positive : Theme.accent
+    seal: _heal ? "治" : "傷"
+    accent: _accent
+    accentDark: Qt.darker(_accent, 1.3)
+    title: _heal ? qsTr("Heal Wounds") : qsTr("Inflict Wounds")
+    tagline: _heal ? qsTr("bind the body's hurts") : qsTr("the strike lands and the flesh remembers")
+    acceptText: _heal ? qsTr("Heal") : qsTr("Inflict")
+    acceptGlyph: _heal ? "治" : "傷"
+    acceptEnabled: root._valid
+    statusText: root._valid ? qsTr("Wounds: %1 → %2 of %3").arg(root._cur).arg(root._result).arg(root._max) : qsTr("Enter how many wounds to apply.")
+    onAccepted: {
+        if (!root._valid || !appCtrl)
+            return;
+        appCtrl.damageHealth(root._heal ? -root._amount : root._amount);
+    }
+
+    // --- entrypoint -----------------------------------------------
+    // `heal` is optional; default mode is inflict.
+    function present(heal) {
+        root._heal = heal === true;
+        amountField.text = "1";
+        root.open();
+        amountField.forceActiveFocus();
+        amountField.selectAll();
+    }
+
+    // --- body -----------------------------------------------------
+    contentItem: ColumnLayout {
+        spacing: Theme.s4
+
+        // ---- Mode selector (Inflict | Heal) ----------------------
+        // Two mutually-exclusive segments; `_heal` is the single source of
+        // truth, so no ButtonGroup is needed (same shape as the element
+        // tiles in ChooseElementDialog). The active segment fills with its
+        // mode hue; the inactive one is outlined with a faint hover wash.
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.s2
+
+            Repeater {
+                model: [
+                    {
+                        "heal": false,
+                        "label": qsTr("Inflict"),
+                        "hue": Theme.accent
+                    },
+                    {
+                        "heal": true,
+                        "label": qsTr("Heal"),
+                        "hue": Theme.positive
+                    }
+                ]
+                delegate: AbstractButton {
+                    id: seg
+                    required property var modelData
+                    readonly property bool _on: root._heal === modelData.heal
+                    Layout.fillWidth: true
+                    implicitHeight: 38
+                    onClicked: root._heal = modelData.heal
+
+                    background: Rectangle {
+                        radius: 3
+                        color: seg._on ? seg.modelData.hue : (seg.hovered ? Qt.rgba(seg.modelData.hue.r, seg.modelData.hue.g, seg.modelData.hue.b, 0.12) : "transparent")
+                        border.color: seg.modelData.hue
+                        border.width: seg._on ? 0 : 1
+                        Behavior on color {
+                            ColorAnimation {
+                                duration: Theme.durHover
+                            }
+                        }
+                    }
+                    contentItem: Label {
+                        text: seg.modelData.label.toUpperCase()
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        font.family: Theme.fontDisplay
+                        font.pixelSize: Theme.fsLabel
+                        font.weight: Theme.wSemiBold
+                        font.letterSpacing: 1.2
+                        color: seg._on ? Theme.whiteWash : Theme.ink
+                    }
+                }
+            }
+        }
+
+        // ---- Amount ----------------------------------------------
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 3
+            Label {
+                text: qsTr("AMOUNT")
+                font.family: Theme.fontDisplay
+                font.pixelSize: Theme.fsCaption
+                font.weight: Theme.wSemiBold
+                font.letterSpacing: 1.4
+                color: Theme.heading
+            }
+            TextField {
+                id: amountField
+                Layout.fillWidth: true
+                implicitHeight: 34
+                text: "1"
+                inputMethodHints: Qt.ImhDigitsOnly
+                validator: IntValidator {
+                    bottom: 1
+                    top: 999
+                }
+                placeholderText: qsTr("number of wounds")
+                color: Theme.ink
+                placeholderTextColor: Theme.inkFaint
+                font.family: Theme.fontBody
+                font.pixelSize: Theme.fsBody
+                background: Rectangle {
+                    color: Theme.parchmentBase
+                    border.color: amountField.activeFocus ? root._accent : Theme.borderSubtle
+                    border.width: 1
+                    radius: 2
+                }
+                // Enter accepts when valid.
+                onAccepted: {
+                    if (root._valid)
+                        root.accept();
+                }
+            }
+        }
+    }
+}

--- a/l5r/qmlui/qml/widgets/WoundsBlock.qml
+++ b/l5r/qmlui/qml/widgets/WoundsBlock.qml
@@ -5,7 +5,7 @@
 // pcProxy, and routes mutations through appCtrl.damageHealth /
 // setWoundsTotal / resetWounds (so the dirty flag stays correct).
 // Interactions:
-//   * stepper [- N +]  -> appCtrl.damageHealth(+/-1)
+//   * Heal/Damage btn  -> DamageHealDialog -> appCtrl.damageHealth(+/-N)
 //   * click card       -> appCtrl.setWoundsTotal(bucketStart) ; HEALTHY = 0
 //   * shift+click card -> appCtrl.resetWounds() (heals to zero)
 // A header tooltip carries the legend (cell layout / formula / interaction)
@@ -16,6 +16,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Theme 1.0
 import ClanTheme 1.0
+
+import "../dialogs" as Dialogs
 
 Pane {
     id: panel
@@ -152,21 +154,15 @@ Pane {
                 }
             }
             Item {
-                Layout.preferredWidth: 8
+                Layout.preferredWidth: 12
             }
-            Label {
-                text: qsTr("current")
-                font.pixelSize: Theme.fsCaption
-                opacity: 0.6
-            }
-            RankStepper {
-                value: panel._cur
-                from: 0
-                to: Math.max(0, panel._max)
-                onValueModified: function (v) {
-                    if (appCtrl)
-                        appCtrl.setWoundsTotal(v);
-                }
+            // Heal/Damage opens a dialog to apply a *batch* of wounds at
+            // once (the game inflicts many wounds per hit, not one click at
+            // a time). Defaults to "inflict"; the dialog flips to heal.
+            L5RButton {
+                text: qsTr("Heal / Damage")
+                glyph: "傷"
+                onClicked: damageHealDlg.present(false)
             }
         }
 
@@ -352,5 +348,11 @@ Pane {
                 }
             }
         }
+    }
+
+    // Batch heal/damage entry. Self-contained here since it only acts on
+    // the wounds total; opened by the header button (default: inflict).
+    Dialogs.DamageHealDialog {
+        id: damageHealDlg
     }
 }


### PR DESCRIPTION
## What

Replaces the per-wound `+/-` stepper in the QML wounds panel (`WoundsBlock`) with a **Heal / Damage** button that opens a dedicated batch-entry dialog.

The stepper made the player click N times to apply a single hit, which does not match how L5R deals damage — one roll inflicts many wounds at once.

## How

**New `l5r/qmlui/qml/dialogs/DamageHealDialog.qml`:**
- Two-segment **Inflict | Heal** selector — defaults to **Inflict**.
- Positive-integer amount field (`IntValidator` 1–999, digits-only IME, Enter accepts).
- Live footer preview: `Wounds: <cur> → <result> of <max>`.
- Accent + seal follow the mode: crimson `傷` for inflict, green `治` for heal.
- On accept routes through the existing `appCtrl.damageHealth(±n)` — same path the old stepper used, so the dirty flag and the narrow `wounds_changed` signal stay correct. No new proxy/controller surface.

**`l5r/qmlui/qml/widgets/WoundsBlock.qml`:**
- Dropped the `current` `RankStepper`; added the `L5RButton` that opens the dialog.
- Added the self-contained dialog instance + `../dialogs` import.
- Multiplier stepper and click / shift-click card interactions untouched.

All colours/fonts/spacing derive from the `Theme` singleton per the UI design system.

## Test

- Both QML files load with `Status.Ready` (no syntax/import errors) via a headless `QQmlComponent` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)