### PR TITLE
fix(schools): backwards-compatible school_rank for legacy saves

### DIFF
--- a/l5r/api/character/schools.py
+++ b/l5r/api/character/schools.py
@@ -159,7 +159,13 @@ def get_tech_by_rank(rank):
     if not school_:
         return None
 
-    return query(school_.techs).where(lambda x: x.rank == (rank_[0].school_rank)).select(a_('id')).first_or_default(None)
+    # backwards compatibility: characters saved before school_rank was tracked
+    # on the Rank advancement (commit 22b28a1) have school_rank == 0. Those old
+    # versions matched the technique on the insight rank directly, so fall back
+    # to that behaviour when school_rank is missing.
+    school_rank = rank_[0].school_rank or rank
+
+    return query(school_.techs).where(lambda x: x.rank == school_rank).select(a_('id')).first_or_default(None)
 
 
 def get_school_rank(sid):

--- a/l5r/models/chmodel.py
+++ b/l5r/models/chmodel.py
@@ -161,6 +161,14 @@ def _load_advancement(data):
     if data.get('type') == 'rank':
         a = Rank()
         a.__dict__.update(data)
+        # backwards compatibility: characters saved before school_rank was
+        # tracked on the Rank advancement (commit 22b28a1) load it as 0. Those
+        # old versions matched the technique on the insight rank directly, so
+        # back-fill school_rank with the insight rank, correcting the save in
+        # place (it persists on the next save). Mirrors the read-time fallback
+        # in api.character.schools.get_tech_by_rank.
+        if not a.school_rank:
+            a.school_rank = a.rank
         a.skills_to_choose = [_rehydrate_wildcard_set(x)
                               for x in (a.skills_to_choose or [])]
         a.merits = [_rehydrate_perk(x) for x in (a.merits or [])]


### PR DESCRIPTION
@
## Problem
Characters created with an older version of the software have the wrong value in `school_rank`. The lookup in `get_tech_by_rank` was changed in 22b28a1 to match on `Rank.school_rank` (to support Advanced-school edge cases), but this was not backwards-compatible: saves predating that commit load `school_rank` as `0`, so `techs.where(rank == 0)` matches nothing and the characters school techniques disappear.

## Fix
- **`api/character/schools.py`** — `get_tech_by_rank` falls back to the insight `rank` when `school_rank` is missing/0, restoring the pre-22b28a1 behaviour at read time.
- **`models/chmodel.py`** — `_load_advancement` back-fills `school_rank` with the insight `rank` on load when it is 0, so the save is corrected in place and persists on the next save (self-healing). Mirrors the read-time fallback.

Both paths use the same fallback value, so they stay consistent. Newly-created characters are unaffected (their `school_rank` is always populated, so the `0` guard never triggers).

## Testing
- `l5r.models.tests.test_chmodel_roundtrip` passes.

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
