### PR TITLE
fix(api): lazily expose data/character submodules as attributes

### DIFF
--- a/l5r/api/character/__init__.py
+++ b/l5r/api/character/__init__.py
@@ -913,3 +913,31 @@ def touch_modifiers():
     fields); this is the setter that owns the dirty flag for that path,
     mirroring api.character.weapons.touch()."""
     set_dirty_flag(True)
+
+
+# Public submodules reached via attribute access (e.g. ``api.character.schools``).
+# They are resolved lazily on first access so they are always available
+# regardless of import order — running a single test module in isolation no
+# longer fails with ``module 'l5r.api.character' has no attribute 'schools'``.
+# Lazy (PEP 562) rather than eager imports here to avoid the circular import
+# between these submodules and ``l5r.models.chmodel`` during package init.
+_SUBMODULES = frozenset((
+    'books',
+    'flaws',
+    'merits',
+    'powers',
+    'rankadv',
+    'schools',
+    'skills',
+    'spells',
+    'weapons',
+))
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        import importlib
+        mod = importlib.import_module(f'{__name__}.{name}')
+        globals()[name] = mod
+        return mod
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/l5r/api/data/__init__.py
+++ b/l5r/api/data/__init__.py
@@ -186,3 +186,32 @@ class CMErrors(object):
     NO_ERROR = 'no_error'
     NOT_ENOUGH_XP = 'not_enough_xp'
     INTERNAL_ERROR = 'internal_error'
+
+
+# Public submodules reached via attribute access (e.g. ``api.data.families``).
+# They are resolved lazily on first access so they are always available
+# regardless of import order — running a single test module in isolation no
+# longer fails with ``module 'l5r.api.data' has no attribute 'families'``.
+# Lazy (PEP 562) rather than eager imports here to avoid the circular import
+# between these submodules and ``l5r.models.chmodel`` during package init.
+_SUBMODULES = frozenset((
+    'clans',
+    'datapacks',
+    'families',
+    'flaws',
+    'merits',
+    'outfit',
+    'powers',
+    'schools',
+    'skills',
+    'spells',
+))
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        import importlib
+        mod = importlib.import_module(f'{__name__}.{name}')
+        globals()[name] = mod
+        return mod
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Problem

Running a single test module in isolation failed, e.g.:

```
QT_QPA_PLATFORM=offscreen python -m unittest l5r.api.tests.test_character
```

with `AttributeError: module 'l5r.api.data' has no attribute 'families'`.

Production code reaches submodules via attribute access
(`api.data.families.get_family_trait(...)`, `api.character.schools.set_first(...)`),
but the `l5r/api/data` and `l5r/api/character` packages never imported their own
submodules. A submodule attribute only exists once *something* has imported it.
Under `unittest discover` (full run) another module imported them first
(e.g. `test_rules_health.py` has `import l5r.api.data.families`), registering them
in `sys.modules`. Running a single module never triggered that chain.

## Fix

Add a PEP 562 `__getattr__` to both package `__init__` files that imports the
public submodules on first access, so they are always available regardless of
import order.

Lazy rather than eager imports here to avoid the circular import
`chmodel → api.rules → api.character → powers → charsnapshot → chmodel`
that an eager static import surfaces during package init.

## Verification

- `test_character` in isolation: **21 OK** (previously 13 errors)
- Full `unittest discover -s l5r`: **145 OK** (identical to baseline, no regression)
- Several other modules in isolation: all OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)