### PR TITLE
feat(qml): responsive sidebar + user-selectable UI text size

### DIFF
--- a/docs/L5R_UI_Design_System.md
+++ b/docs/L5R_UI_Design_System.md
@@ -205,6 +205,43 @@ All spacing derives from an **8 px base unit**.
 - **Header bar height:** 56 px; background `--color-accent-crimson-bg` (Burden) or `--color-accent-blue-bg` (Blessing)
 - **Status/footer bar height:** 48 px; background `--color-paper-dark`; 1 px top border `--color-parchment-border`
 
+### 4.4 Responsive Layout (compact / mobile)
+
+The main-window layout has two forms, switched at a single breakpoint:
+
+- **`--bp-compact` = 760 px** (`Theme.bpCompact`): the window-width threshold
+  below which the fixed sidebar can no longer share the row with a usable
+  (≥ 520 px) content area.
+
+**Wide (≥ `--bp-compact`)** — the standard form of §4.2: the nav sidebar is
+pinned as a fixed column, the content area fills the rest.
+
+**Compact (< `--bp-compact`)** — phones in portrait, narrow windows:
+
+```
+┌──────────────────────────────────────┐
+│ ☰  Character Name            (app bar)│  ← slim top bar, paper-dark band
+├──────────────────────────────────────┤
+│              CONTENT AREA             │  ← full width
+│              (full width)             │
+└──────────────────────────────────────┘
+   ☰ opens the sidebar as a left-edge Drawer overlay
+```
+
+- The sidebar collapses out of the row and is hosted instead in a **left-edge
+  `Drawer`** overlay (width `min(280, 85% of window)`), opened by a **hamburger
+  button** in a slim top app-bar.
+- The top app-bar is a paper-dark band (same treatment as the menu bar, §6.1 /
+  §8.3) carrying the hamburger on the left and the **character name** (the
+  identity normally pinned in the sidebar header) beside it.
+- Selecting a section in the drawer navigates and dismisses the drawer.
+- The breakpoint is a **window-width** test, so the layout reflows live on
+  desktop resize and on device rotation alike — landscape phones/tablets get
+  the wide form, portrait phones get the compact form.
+
+The active-section state is a single source of truth shared by both the fixed
+sidebar and the drawer copy, so the highlight never desyncs between them.
+
 ---
 
 ## 5. Clan Accent Overrides

--- a/l5r/qmlui/proxies/settings_proxy.py
+++ b/l5r/qmlui/proxies/settings_proxy.py
@@ -59,6 +59,24 @@ _INSIGHT_METHODS = [
     (3, "Account Rank 1 School Skills"),
 ]
 
+# UI text-size choices. The id is the persisted key (settings.app
+# ui_font_size); the scale is the multiplier pushed onto Theme.fontScale
+# (see _FONT_SCALES). Only two choices are offered, per the design intent:
+# "Standard" (1.0) and "Large" (1.25).
+_FONT_SIZES = [
+    ("standard", "Standard"),
+    ("large", "Large"),
+    ("larger", "Larger"),
+    ("huge", "Huge"),
+]
+
+_FONT_SCALES = {
+    "standard": 1.0,
+    "large": 1.15,
+    "larger": 1.25,
+    "huge": 1.45,
+}
+
 
 class SettingsProxy(QObject):
     """Read/write bridge over L5RCMSettings for the QML Settings section."""
@@ -70,6 +88,7 @@ class SettingsProxy(QObject):
     printCurrentArmorTnChanged = Signal()
     useQmlUiChanged = Signal()
     buyForFreeChanged = Signal()
+    fontSizeChanged = Signal()
 
     # Emitted when a setting was persisted but cannot take effect until the
     # app is restarted (language, front-end switch). Carries the message
@@ -91,6 +110,11 @@ class SettingsProxy(QObject):
     def insightMethods(self):
         return [{"id": value, "name": self.tr(label)}
                 for value, label in _INSIGHT_METHODS]
+
+    @Property("QVariantList", constant=True)
+    def fontSizes(self):
+        return [{"id": key, "name": self.tr(label)}
+                for key, label in _FONT_SIZES]
 
     # --- localization ------------------------------------------------
 
@@ -172,6 +196,29 @@ class SettingsProxy(QObject):
             return
         l5r.models.Advancement.set_buy_for_free(value)
         self.buyForFreeChanged.emit()
+
+    # --- UI text size (applied live via Theme.fontScale) -------------
+    # Persisted preference that scales the whole type scale. The QML
+    # root binds Theme.fontScale to `fontScale` below, so changing it
+    # takes effect at once -- no restart needed.
+
+    @Property(str, notify=fontSizeChanged)
+    def fontSize(self):
+        value = self._settings.app.ui_font_size or "standard"
+        return value if value in _FONT_SCALES else "standard"
+
+    @Property(float, notify=fontSizeChanged)
+    def fontScale(self):
+        return _FONT_SCALES.get(self.fontSize, 1.0)
+
+    @Slot(str)
+    def setFontSize(self, value):
+        value = value if value in _FONT_SCALES else "standard"
+        if value == self.fontSize:
+            return
+        self._settings.app.ui_font_size = value
+        self._settings.sync()
+        self.fontSizeChanged.emit()
 
     # --- PDF export (read by the exporter at export time) ------------
 

--- a/l5r/qmlui/qml/MainSheet.qml
+++ b/l5r/qmlui/qml/MainSheet.qml
@@ -28,6 +28,26 @@ ApplicationWindow {
     // the whole sheet reads in the clan's hue.
     color: ClanTheme.paper
 
+    // Responsive layout (design system §4.4). Below bpCompact the nav
+    // sidebar can't share the row with a usable content area, so it
+    // collapses behind a hamburger drawer and a slim top app-bar appears.
+    // Phones in portrait go compact; tablets / desktop stay wide.
+    readonly property bool compact: width < Theme.bpCompact
+
+    // Single source of truth for the active section. Both the fixed
+    // sidebar and the drawer sidebar bind their TOC currentIndex to this
+    // (one-way), and the scroll-sync timer writes it, so the highlight
+    // never desyncs between the two hosted copies of the sidebar.
+    property int currentSection: 0
+
+    // Navigate to a section: highlight its TOC row and scroll the sheet
+    // to it. Routed through here by every nav source (TOC click, library
+    // nudge) so the single currentSection stays authoritative.
+    function navigateTo(index) {
+        currentSection = index;
+        jumpTo(index);
+    }
+
     // Drive the per-clan accent (design system §5): push the active
     // character's clan id into the ClanTheme singleton whenever it
     // changes, so the sidebar accent re-tints while the layout stays
@@ -127,6 +147,136 @@ ApplicationWindow {
         }
     }
 
+    // Compact top app-bar (design system §4.4): shown only below the
+    // bpCompact width, where the fixed sidebar is collapsed into navDrawer.
+    // It carries the hamburger that opens the drawer plus the character
+    // name (the identity block normally pinned in the sidebar), so the
+    // player never loses sight of who they're editing. Styled as the same
+    // darker-parchment band as the menu bar. On wide layouts it is hidden
+    // and collapsed to zero height, so the desktop chrome is unchanged
+    // (ApplicationWindow reserves no space for a hidden header).
+    header: ToolBar {
+        id: compactBar
+        visible: root.compact
+        height: root.compact ? implicitHeight : 0
+
+        background: Rectangle {
+            color: ClanTheme.paperSidebar
+            Widgets.RicePaperOverlay {
+            }
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: 1
+                color: Theme.divider
+                opacity: Theme.dividerOpacity
+            }
+        }
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: Theme.s2
+            anchors.rightMargin: Theme.s3
+            spacing: Theme.s2
+
+            // Hamburger: three ink strokes on a transparent button that
+            // warms to the clan accent wash on press, matching the menu
+            // bar items' feedback language.
+            ToolButton {
+                id: hamburger
+                implicitWidth: 40
+                implicitHeight: 40
+                padding: 0
+                Layout.alignment: Qt.AlignVCenter
+                onClicked: navDrawer.open()
+                ToolTip.visible: hovered
+                ToolTip.text: qsTr("Sections")
+                background: Rectangle {
+                    radius: 4
+                    color: (hamburger.down || hamburger.hovered) ? ClanTheme.selectedBg : "transparent"
+                    Behavior on color {
+                        ColorAnimation {
+                            duration: Theme.durHover
+                            easing.type: Easing.OutQuad
+                        }
+                    }
+                }
+                // The contentItem fills the button's content area, so the
+                // three strokes must be centred within it (both axes) --
+                // otherwise they sit top-left and read as misaligned with
+                // the name label beside them.
+                contentItem: Item {
+                    Column {
+                        anchors.centerIn: parent
+                        spacing: 4
+                        Repeater {
+                            model: 3
+                            delegate: Rectangle {
+                                width: 20
+                                height: 2
+                                radius: 1
+                                color: (hamburger.down || hamburger.hovered) ? ClanTheme.primary : Theme.ink
+                            }
+                        }
+                    }
+                }
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+                text: (pcProxy && pcProxy.name) ? pcProxy.name : qsTr("Unnamed")
+                font.family: Theme.fontDisplay
+                font.pixelSize: Theme.fsHeading2
+                font.weight: Theme.wSemiBold
+                font.letterSpacing: 0.5
+                color: Theme.heading
+                elide: Text.ElideRight
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
+    }
+
+    // Drawer hosting the nav sidebar in compact mode. Slides in from the
+    // left edge over the sheet; dismissed by tapping outside, by the back
+    // gesture, or by activating a section. Built only when compact so it
+    // never intercepts edge swipes on the desktop layout.
+    Drawer {
+        id: navDrawer
+        edge: Qt.LeftEdge
+        // Roomy enough for the longest section title, capped so it never
+        // swallows the whole phone screen.
+        width: Math.min(280, root.width * 0.85)
+        height: root.height
+        // The fixed sidebar already covers wide layouts; keep the drawer
+        // inert (and its content unbuilt) there.
+        interactive: root.compact
+        dim: true
+        // No padding gap, and a parchment background so no grey Fusion
+        // panel shows behind / around the sidebar while it slides in.
+        padding: 0
+        background: Rectangle {
+            color: ClanTheme.paperSidebar
+        }
+
+        // Loader-gated so the drawer's copy of the sidebar (a second TOC
+        // bound to appCtrl.tabs) is only instantiated in compact mode --
+        // on desktop the fixed sidebar is the only one built.
+        Loader {
+            anchors.fill: parent
+            active: root.compact
+            sourceComponent: Component {
+                Widgets.SheetSidebar {
+                    currentIndex: root.currentSection
+                    onSectionActivated: function (index) {
+                        root.navigateTo(index);
+                        navDrawer.close();
+                    }
+                }
+            }
+        }
+    }
+
     // Children of `sheetColumn` are SectionBlock items in the same order
     // as appCtrl.tabs. We use sheetRepeater.itemAt(i) to read each one's
     // y coordinate, which the Column layout supplies for us.
@@ -184,10 +334,8 @@ ApplicationWindow {
 
     function jumpToLibrary() {
         var i = libraryIndex();
-        if (i >= 0) {
-            toc.currentIndex = i;
-            jumpTo(i);
-        }
+        if (i >= 0)
+            navigateTo(i);
     }
 
     // Update the active-section highlight when scrolling goes idle, not
@@ -203,7 +351,7 @@ ApplicationWindow {
         id: tocSyncTimer
         interval: 120
         repeat: false
-        onTriggered: toc.currentIndex = root.activeSectionFromContentY(flick.contentY)
+        onTriggered: root.currentSection = root.activeSectionFromContentY(flick.contentY)
     }
 
     NumberAnimation {
@@ -244,232 +392,24 @@ ApplicationWindow {
             anchors.fill: parent
             spacing: 0
 
-            // ---- Left TOC --------------------------------------------------
-            Rectangle {
-                Layout.preferredWidth: 220
+            // ---- Left TOC (fixed, wide layouts only) ----------------------
+            // On compact layouts the same SheetSidebar is hosted in
+            // navDrawer instead; here it collapses out of the row (zero
+            // width) so the sheet gets the full width.
+            Widgets.SheetSidebar {
+                Layout.preferredWidth: root.compact ? 0 : 220
                 Layout.fillHeight: true
-                // Slightly darker parchment than the main sheet so the
-                // navigation column reads as a distinct zone without
-                // breaking the "one document" illusion.
-                color: ClanTheme.paperSidebar
-
-                // Same fibre texture as the main sheet so the sidebar
-                // reads as the same paper, just a darker shade -- not a
-                // flat coloured panel glued onto the document.
-                Widgets.RicePaperOverlay {
-                }
-
-                ColumnLayout {
-                    anchors.fill: parent
-                    anchors.topMargin: 14
-                    anchors.bottomMargin: 8
-                    anchors.leftMargin: 10
-                    anchors.rightMargin: 10
-                    spacing: 6
-
-                    // ---- Identity block ----------------------------------
-                    // Three-line character header above the TOC: name in
-                    // burnt-gold display type, clan + rank as a single
-                    // secondary line, school italicised underneath. Reads
-                    // like the title block of a character sheet rather
-                    // than a piece of chrome.
-                    ColumnLayout {
-                        Layout.fillWidth: true
-                        spacing: 1
-
-                        Label {
-                            Layout.fillWidth: true
-                            text: (pcProxy && pcProxy.name) ? pcProxy.name : qsTr("Unnamed")
-                            font.family: Theme.fontDisplay
-                            font.pixelSize: 17
-                            font.weight: Font.DemiBold
-                            font.letterSpacing: 0.5
-                            color: Theme.heading
-                            elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignHCenter
-                        }
-                        Label {
-                            Layout.fillWidth: true
-                            readonly property string _clan: (pcProxy && pcProxy.clan) ? pcProxy.clan : ""
-                            readonly property int _rank: pcProxy ? pcProxy.progression.rank : 0
-                            text: {
-                                var clanFmt = _clan ? _clan.charAt(0).toUpperCase() + _clan.slice(1) : qsTr("No Clan");
-                                return clanFmt + " — " + qsTr("Rank %1").arg(_rank);
-                            }
-                            font.pixelSize:Theme.fsBody 
-                            font.features: Theme.tabularNumbers
-                            color: palette.windowText
-                            opacity: 0.85
-                            elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignHCenter
-                        }
-                        Label {
-                            Layout.fillWidth: true
-                            text: (pcProxy && pcProxy.school) ? pcProxy.school : qsTr("No School")
-                            font.pixelSize: Theme.fsCaption
-                            font.italic: true
-                            color: palette.windowText
-                            opacity: 0.7
-                            elide: Text.ElideRight
-                            horizontalAlignment: Text.AlignHCenter
-                        }
-                    }
-
-                    Widgets.OrnateDivider {
-                        Layout.fillWidth: true
-                        Layout.topMargin: 4
-                        Layout.bottomMargin: 2
-                    }
-
-                    ListView {
-                        id: toc
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        model: appCtrl ? appCtrl.tabs : []
-                        clip: true
-                        currentIndex: 0
-                        spacing: 2
-                        interactive: true
-                        boundsBehavior: Flickable.StopAtBounds
-
-                        delegate: ItemDelegate {
-                            id: tocDelegate
-                            width: ListView.view.width
-                            height: 38
-                            highlighted: ListView.isCurrentItem
-                            // Re-evaluate when appCtrl.hiddenSections changes.
-                            readonly property bool sectionIsHidden: root.sectionHidden(modelData.id)
-                            readonly property bool sectionIsFixed: root.sectionFixed(modelData.id)
-                            onClicked: {
-                                // A hidden row is inert, like a disabled
-                                // control: clicking its body does nothing.
-                                // Only the eye toggle brings it back.
-                                if (tocDelegate.sectionIsHidden)
-                                    return;
-                                toc.currentIndex = index;
-                                root.jumpTo(index);
-                            }
-
-                            // Strip the default Control background -- without
-                            // this override, ItemDelegate paints a palette-
-                            // driven fill that reads as flat grey on top of
-                            // the parchment sidebar.  Hover gets a warm wash
-                            // (lighter parchment), idle is fully transparent
-                            // so the sidebar texture shows through.
-                            background: Rectangle {
-                                // No hover wash on a hidden row -- it's inert,
-                                // so it shouldn't invite a click (the eye has
-                                // its own hover feedback).
-                                color: (tocDelegate.hovered && !tocDelegate.sectionIsHidden) ? Qt.lighter(ClanTheme.paperSidebar, 1.07) : "transparent"
-                            }
-
-                            // Active item: accent stripe on the left, accent
-                            // icon, accent-tinted label.  Inactive: normal
-                            // palette text colours so the OS theme is honoured.
-                            Rectangle {
-                                anchors.left: parent.left
-                                anchors.top: parent.top
-                                anchors.bottom: parent.bottom
-                                width: 3
-                                color: ClanTheme.primary
-                                visible: tocDelegate.highlighted
-                            }
-                            contentItem: RowLayout {
-                                spacing: 10
-                                // Brush-script kanji; the Hakushū Higerei face
-                                // has heavier strokes than a system CJK font
-                                // so 20px is comfortable here without crowding
-                                // the column.
-                                Label {
-                                    text: modelData.icon
-                                    font.family: Theme.fontKanji
-                                    font.pixelSize: 22
-                                    Layout.leftMargin: 14
-                                    Layout.preferredWidth: 28
-                                    horizontalAlignment: Text.AlignHCenter
-                                    color: tocDelegate.highlighted ? ClanTheme.primary : palette.windowText
-                                    // Dim a hidden section's row so it reads
-                                    // as "off" yet stays available to re-show.
-                                    opacity: tocDelegate.sectionIsHidden ? 0.35 : (tocDelegate.highlighted ? 1.0 : 0.7)
-                                }
-                                Label {
-                                    text: modelData.title
-                                    font.pixelSize: 12
-                                    Layout.fillWidth: true
-                                    elide: Text.ElideRight
-                                    color: tocDelegate.highlighted ? ClanTheme.primary : palette.windowText
-                                    font.weight: tocDelegate.highlighted ? Font.DemiBold : Font.Normal
-                                    opacity: tocDelegate.sectionIsHidden ? 0.35 : 1.0
-                                }
-
-                                // Opportunity badge -- a count of pending
-                                // "you unlocked something" actions resolved
-                                // in this section (free kiho today; granted
-                                // skills / spells / rank-up as those flows
-                                // are ported). Accent-blue per the §6.16
-                                // positive-action language -- crimson is
-                                // reserved for destructive/unmet, so this
-                                // reads as an invitation, not an alarm.
-                                Rectangle {
-                                    readonly property int _count: (pcProxy && pcProxy.opportunityBadges && pcProxy.opportunityBadges[modelData.id] !== undefined) ? pcProxy.opportunityBadges[modelData.id] : 0
-                                    visible: _count > 0
-                                    Layout.rightMargin: 12
-                                    Layout.alignment: Qt.AlignVCenter
-                                    implicitWidth: Math.max(18, badgeCount.implicitWidth + 10)
-                                    implicitHeight: 18
-                                    radius: 9
-                                    color: Theme.secondary
-                                    Label {
-                                        id: badgeCount
-                                        anchors.centerIn: parent
-                                        text: parent._count
-                                        font.family: Theme.fontStat
-                                        font.pixelSize: Theme.fsCaption
-                                        font.weight: Theme.wSemiBold
-                                        font.features: Theme.tabularNumbers
-                                        color: Theme.whiteWash
-                                    }
-                                }
-
-                                // Visibility toggle: a brush 見 ("view")
-                                // glyph, matching the kanji section icons.
-                                // Shown on hover, or always while the row is
-                                // hidden so it can be brought back. Never on
-                                // the fixed sections (pc_info / about).
-                                ToolButton {
-                                    id: eyeBtn
-                                    visible: !tocDelegate.sectionIsFixed && (tocDelegate.hovered || tocDelegate.sectionIsHidden)
-                                    Layout.rightMargin: 12
-                                    Layout.alignment: Qt.AlignVCenter
-                                    implicitWidth: 22
-                                    implicitHeight: 22
-                                    padding: 0
-                                    background: Rectangle {
-                                        radius: 4
-                                        color: eyeBtn.hovered ? Qt.lighter(ClanTheme.paperSidebar, 1.12) : "transparent"
-                                    }
-                                    contentItem: Label {
-                                        text: "見"
-                                        font.family: Theme.fontKanji
-                                        font.pixelSize: 15
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                        color: tocDelegate.highlighted ? ClanTheme.primary : palette.windowText
-                                        opacity: tocDelegate.sectionIsHidden ? 0.9 : (eyeBtn.hovered ? 1.0 : 0.5)
-                                    }
-                                    onClicked: appCtrl.setSectionHidden(modelData.id, !tocDelegate.sectionIsHidden)
-                                    ToolTip.visible: hovered
-                                    ToolTip.text: tocDelegate.sectionIsHidden ? qsTr("Show section") : qsTr("Hide section")
-                                }
-                            }
-                        }
-                    }
+                visible: !root.compact
+                currentIndex: root.currentSection
+                onSectionActivated: function (index) {
+                    root.navigateTo(index);
                 }
             }
 
             Rectangle {
                 Layout.preferredWidth: 1
                 Layout.fillHeight: true
+                visible: !root.compact
                 color: Theme.divider
                 opacity: Theme.dividerOpacity
             }
@@ -597,7 +537,9 @@ ApplicationWindow {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.leftMargin: 221
+        // Clear the fixed sidebar (220px + 1px divider) on wide layouts;
+        // in compact mode there is no sidebar, so span the full width.
+        anchors.leftMargin: root.compact ? 0 : 221
         height: visible ? 44 : 0
         color: Theme.parchmentSidebar
 

--- a/l5r/qmlui/qml/MainSheet.qml
+++ b/l5r/qmlui/qml/MainSheet.qml
@@ -53,7 +53,13 @@ ApplicationWindow {
     // changes, so the sidebar accent re-tints while the layout stays
     // put. Guarded for the null first pass; the Connections covers
     // File>New / open / family edit (all routed through clanChanged).
+    // Bind the global text-scale multiplier to the user's "Text size"
+    // preference. QML singletons can't see context properties, so the
+    // binding is installed here (the root sees appSettings) and pushed
+    // onto Theme.fontScale; the whole type scale then re-scales live.
     Component.onCompleted: {
+        Theme.fontScale = Qt.binding(
+            () => appSettings ? appSettings.fontScale : 1.0);
         if (pcProxy)
             ClanTheme.setClan(pcProxy.clanId);
         // First-run nudge: with no datapacks the app is near-useless, so

--- a/l5r/qmlui/qml/SectionBlock.qml
+++ b/l5r/qmlui/qml/SectionBlock.qml
@@ -225,7 +225,7 @@ Item {
                         anchors.centerIn: parent
                         text: qsTr("Section '%1' content coming soon").arg(section.tabId)
                         opacity: 0.7
-                        font.pixelSize: 13
+                        font.pixelSize: Theme.fsBody
                     }
                 }
             }

--- a/l5r/qmlui/qml/Theme/Theme.qml
+++ b/l5r/qmlui/qml/Theme/Theme.qml
@@ -95,6 +95,14 @@ QtObject {
     readonly property int s6: 32   // dialog internal sections
     readonly property int s7: 48   // top/bottom margins on major containers
 
+    // --- responsive breakpoint (design system §4.4) ---------------
+    // Below this window width the main-window layout switches from the
+    // fixed-sidebar form to the compact form: the nav sidebar collapses
+    // behind a hamburger drawer and a slim top app-bar appears. Sized so
+    // a 240px sidebar + a >=520px content area no longer fit comfortably
+    // -- i.e. phones in portrait go compact, tablets / desktop stay wide.
+    readonly property int bpCompact: 760
+
     // Component-local metrics, NOT part of the global scale: the
     // social / void point-track dots (design §6.12 fixes the dot at
     // 14px with a 4px gap).

--- a/l5r/qmlui/qml/Theme/Theme.qml
+++ b/l5r/qmlui/qml/Theme/Theme.qml
@@ -172,20 +172,47 @@ QtObject {
     readonly property int wBold: 700        // Font.Bold
     readonly property int wBlack: 900       // Font.Black -- Cinzel display only
 
+    // --- text-size accessibility scale -----------------------------
+    // Global UI text-scale multiplier (1.0 = Standard, 1.25 = Large).
+    // Bound at runtime from appSettings (see MainSheet.qml); only the
+    // type-scale tokens below react to it -- the decorative kanji /
+    // watermark / icon pixel sizes stay fixed by design, so the layout
+    // balance is preserved while the readable text grows.
+    property real fontScale: 1.0
+
     // --- type scale (design system §3.2) ---------------------------
     // fs* = "font size", keyed to the spec's named roles. Display /
     // heading / label / caption pair with fontDisplay or fontBody;
-    // the stat* + xpValue sizes pair with fontStat.
-    readonly property int fsDisplay: 22     // page / section title (Cinzel)
-    readonly property int fsHeading1: 18    // dialog title (Cinzel)
-    readonly property int fsHeading2: 15    // sub-section header (Cinzel)
-    readonly property int fsLabel: 13       // field label, column header (Cinzel)
-    readonly property int fsBody: 13        // description paragraphs, notes (IM Fell)
-    readonly property int fsCaption: 11     // hints, metadata, taglines (IM Fell)
-    readonly property int fsStatLarge: 36   // ring numeral / hero stat (EB Garamond)
-    readonly property int fsStatMedium: 20  // attribute value, insight, rank
-    readonly property int fsStatSmall: 15   // skill rank, xp-cost labels
-    readonly property int fsXpValue: 28     // "+N XP" cost figure (EB Garamond bold)
+    // the stat* + xpValue sizes pair with fontStat. The base px values
+    // below are the §3.2 spec; each is multiplied by fontScale so the
+    // user "Text size" preference scales the whole type scale at once.
+    readonly property int fsDisplay: Math.round(22 * fontScale)     // page / section title (Cinzel)
+    readonly property int fsHeading1: Math.round(18 * fontScale)    // dialog title (Cinzel)
+    readonly property int fsHeading2: Math.round(15 * fontScale)    // sub-section header (Cinzel)
+    readonly property int fsLabel: Math.round(13 * fontScale)       // field label, column header (Cinzel)
+    readonly property int fsBody: Math.round(13 * fontScale)        // description paragraphs, notes (IM Fell)
+    readonly property int fsCaption: Math.round(11 * fontScale)     // hints, metadata, taglines (IM Fell)
+    readonly property int fsStatLarge: Math.round(36 * fontScale)   // ring numeral / hero stat (EB Garamond)
+    readonly property int fsStatMedium: Math.round(20 * fontScale)  // attribute value, insight, rank
+    readonly property int fsStatSmall: Math.round(15 * fontScale)   // skill rank, xp-cost labels
+    readonly property int fsXpValue: Math.round(28 * fontScale)     // "+N XP" cost figure (EB Garamond bold)
+
+    // Sub-caption tier -- below --text-caption (11). Not in the §3.2
+    // role table, but needed for the dense list rows: small inline meta
+    // (fsBodySmall, 12 -- nav/TOC labels, list captions) and the tiny
+    // cost / count / "p.NN" micro-text (fsMicro, 10). Kept equal to the
+    // values previously hard-coded so Standard mode looks identical; they
+    // scale with fontScale like the rest of the type scale. Decorative
+    // kanji / watermark / control glyphs (±, carets, brush icons) stay
+    // fixed and must NOT be migrated onto these tokens.
+    readonly property int fsBodySmall: Math.round(12 * fontScale)   // dense list label / nav TOC row
+    readonly property int fsMicro: Math.round(10 * fontScale)       // cost / count / micro-meta
+
+    // Above-scale focal numeral -- larger than fsStatLarge (36). Used for
+    // the single "hero" figure that anchors a view (the Perks net-XP
+    // verdict at the centre of the scale metaphor). Not a §3.2 role; kept
+    // here so even the focal stat scales with the Text-size preference.
+    readonly property int fsHeroStat: Math.round(44 * fontScale)
 
     // Convenience alias for the Cinzel display weight: wBlack (900).
     // This is the ONLY weight the shipped variable Cinzel renders

--- a/l5r/qmlui/qml/dialogs/AddArmorDialog.qml
+++ b/l5r/qmlui/qml/dialogs/AddArmorDialog.qml
@@ -306,7 +306,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: dlg._selected ? dlg._selected.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -385,7 +385,7 @@ Widgets.L5RDialog {
         Label {
             text: label.toUpperCase()
             font.family: Theme.fontDisplay
-            font.pixelSize: 9
+            font.pixelSize: Theme.fsMicro
             font.weight: Theme.wSemiBold
             font.letterSpacing: 1.2
             color: Theme.inkMuted

--- a/l5r/qmlui/qml/dialogs/AddWeaponDialog.qml
+++ b/l5r/qmlui/qml/dialogs/AddWeaponDialog.qml
@@ -408,7 +408,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: dlg._selected ? dlg._selected.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -547,7 +547,7 @@ Widgets.L5RDialog {
             anchors.centerIn: parent
             text: badge.tag.toUpperCase()
             font.family: Theme.fontDisplay
-            font.pixelSize: 9
+            font.pixelSize: Theme.fsMicro
             font.weight: Theme.wSemiBold
             font.letterSpacing: 1.0
             color: badge._c
@@ -567,7 +567,7 @@ Widgets.L5RDialog {
         Label {
             text: label.toUpperCase()
             font.family: Theme.fontDisplay
-            font.pixelSize: 9
+            font.pixelSize: Theme.fsMicro
             font.weight: Theme.wSemiBold
             font.letterSpacing: 1.2
             color: Theme.inkMuted

--- a/l5r/qmlui/qml/dialogs/BuyKataDialog.qml
+++ b/l5r/qmlui/qml/dialogs/BuyKataDialog.qml
@@ -351,7 +351,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: dlg._selected ? dlg._selected.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -380,7 +380,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: dlg._selected ? (dlg._selected.elementLabel || "").toUpperCase() : ""
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.4
                                 color: Theme.whiteWash
@@ -400,7 +400,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: qsTr("Mastery %1").arg(dlg._selected ? (dlg._selected.mastery || 0) : 0)
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.2
                                 color: detailPane._ringColor
@@ -491,7 +491,7 @@ Widgets.L5RDialog {
                                         Layout.bottomMargin: 5
                                         text: qsTr("XP")
                                         font.family: Theme.fontDisplay
-                                        font.pixelSize: 9
+                                        font.pixelSize: Theme.fsMicro
                                         font.weight: Theme.headingWeight
                                         font.letterSpacing: 2.0
                                         color: dlg._accent

--- a/l5r/qmlui/qml/dialogs/BuyKihoDialog.qml
+++ b/l5r/qmlui/qml/dialogs/BuyKihoDialog.qml
@@ -382,7 +382,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: dlg._selected ? dlg._selected.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -412,7 +412,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: dlg._selected ? (dlg._selected.elementLabel || "").toUpperCase() : ""
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.4
                                 color: Theme.whiteWash
@@ -432,7 +432,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: qsTr("Mastery %1").arg(dlg._selected ? (dlg._selected.mastery || 0) : 0)
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.2
                                 color: detailPane._ringColor
@@ -455,7 +455,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: dlg._selected ? (dlg._selected.typeLabel || "").toUpperCase() : ""
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.2
                                 color: Theme.inkMuted
@@ -548,7 +548,7 @@ Widgets.L5RDialog {
                                         Layout.bottomMargin: 5
                                         text: qsTr("XP")
                                         font.family: Theme.fontDisplay
-                                        font.pixelSize: 9
+                                        font.pixelSize: Theme.fsMicro
                                         font.weight: Theme.headingWeight
                                         font.letterSpacing: 2.0
                                         color: dlg._accent

--- a/l5r/qmlui/qml/dialogs/BuySpellDialog.qml
+++ b/l5r/qmlui/qml/dialogs/BuySpellDialog.qml
@@ -455,7 +455,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: dlg._selected ? dlg._selected.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -487,7 +487,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: dlg._selected ? (dlg._selected.elementLabel || "").toUpperCase() : ""
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.4
                                 color: Theme.whiteWash
@@ -507,7 +507,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: qsTr("Mastery %1").arg(dlg._selected ? (dlg._selected.mastery || 0) : 0)
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.2
                                 color: detailPane._ringColor
@@ -531,7 +531,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: parent.parent._mod > 0 ? qsTr("AFFINITY +%1").arg(parent.parent._mod) : qsTr("DEFICIENCY %1").arg(parent.parent._mod)
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.2
                                 color: parent.parent._mod > 0 ? Theme.positive : Theme.accent
@@ -569,7 +569,7 @@ Widgets.L5RDialog {
                                 Label {
                                     text: modelData.k
                                     font.family: Theme.fontDisplay
-                                    font.pixelSize: 9
+                                    font.pixelSize: Theme.fsMicro
                                     font.weight: Theme.wSemiBold
                                     font.letterSpacing: 1.6
                                     color: Theme.heading
@@ -684,7 +684,7 @@ Widgets.L5RDialog {
                                             anchors.centerIn: parent
                                             text: (modelData || "").toUpperCase()
                                             font.family: Theme.fontDisplay
-                                            font.pixelSize: 9
+                                            font.pixelSize: Theme.fsMicro
                                             font.weight: Theme.wSemiBold
                                             font.letterSpacing: 1.0
                                             color: Theme.inkMuted

--- a/l5r/qmlui/qml/dialogs/BuyTattooDialog.qml
+++ b/l5r/qmlui/qml/dialogs/BuyTattooDialog.qml
@@ -311,7 +311,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: dlg._selected ? dlg._selected.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -341,7 +341,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: qsTr("彫  SACRED MARK")
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.4
                                 color: Theme.whiteWash

--- a/l5r/qmlui/qml/dialogs/ChooseSchoolSpellsDialog.qml
+++ b/l5r/qmlui/qml/dialogs/ChooseSchoolSpellsDialog.qml
@@ -560,7 +560,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: detailPane._rec ? detailPane._rec.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -589,7 +589,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: detailPane._rec ? (detailPane._rec.elementLabel || "").toUpperCase() : ""
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.4
                                 color: Theme.whiteWash
@@ -608,7 +608,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: qsTr("Mastery %1").arg(detailPane._rec ? (detailPane._rec.mastery || 0) : 0)
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.2
                                 color: detailPane._ringColor
@@ -628,7 +628,7 @@ Widgets.L5RDialog {
                                 anchors.centerIn: parent
                                 text: parent.parent._mod > 0 ? qsTr("AFFINITY +%1").arg(parent.parent._mod) : qsTr("DEFICIENCY %1").arg(parent.parent._mod)
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 10
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.2
                                 color: parent.parent._mod > 0 ? Theme.positive : Theme.accent
@@ -664,7 +664,7 @@ Widgets.L5RDialog {
                                 Label {
                                     text: modelData.k
                                     font.family: Theme.fontDisplay
-                                    font.pixelSize: 9
+                                    font.pixelSize: Theme.fsMicro
                                     font.weight: Theme.wSemiBold
                                     font.letterSpacing: 1.6
                                     color: Theme.heading
@@ -716,7 +716,7 @@ Widgets.L5RDialog {
                                     anchors.centerIn: parent
                                     text: (modelData || "").toUpperCase()
                                     font.family: Theme.fontDisplay
-                                    font.pixelSize: 9
+                                    font.pixelSize: Theme.fsMicro
                                     font.weight: Theme.wSemiBold
                                     font.letterSpacing: 1.0
                                     color: Theme.inkMuted

--- a/l5r/qmlui/qml/dialogs/EditPerkDialog.qml
+++ b/l5r/qmlui/qml/dialogs/EditPerkDialog.qml
@@ -254,7 +254,7 @@ Widgets.L5RDialog {
                                 anchors.rightMargin: 6
                                 text: qsTr("XP")
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 9
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.headingWeight
                                 font.letterSpacing: 2.0
                                 color: dlg._isFlaw ? Theme.highlight : dlg._accent
@@ -347,7 +347,7 @@ Widgets.L5RDialog {
                         contentItem: Label {
                             text: qsTr("reset to %1").arg(dlg.suggestedCost)
                             font.family: Theme.fontDisplay
-                            font.pixelSize: 10
+                            font.pixelSize: Theme.fsMicro
                             font.weight: Theme.wSemiBold
                             font.letterSpacing: 1.2
                             color: resetBtn.hovered ? Theme.parchmentBase : Theme.heading

--- a/l5r/qmlui/qml/dialogs/InscribePerkDialog.qml
+++ b/l5r/qmlui/qml/dialogs/InscribePerkDialog.qml
@@ -429,7 +429,7 @@ Widgets.L5RDialog {
                         Layout.fillWidth: true
                         text: dlg._selected ? dlg._selected.name : ""
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsDisplay
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.0
                         color: Theme.heading
@@ -645,7 +645,7 @@ Widgets.L5RDialog {
                                             anchors.rightMargin: 6
                                             text: qsTr("XP")
                                             font.family: Theme.fontDisplay
-                                            font.pixelSize: 9
+                                            font.pixelSize: Theme.fsMicro
                                             font.weight: Theme.headingWeight
                                             font.letterSpacing: 2.0
                                             color: dlg._isFlaw ? Theme.highlight : dlg._accent
@@ -751,7 +751,7 @@ Widgets.L5RDialog {
                                     contentItem: Label {
                                         text: qsTr("reset to %1").arg(dlg._suggestedCost)
                                         font.family: Theme.fontDisplay
-                                        font.pixelSize: 10
+                                        font.pixelSize: Theme.fsMicro
                                         font.weight: Font.DemiBold
                                         font.letterSpacing: 1.2
                                         color: resetBtn.hovered ? Theme.parchmentBase : Theme.heading

--- a/l5r/qmlui/qml/sections/AboutSection.qml
+++ b/l5r/qmlui/qml/sections/AboutSection.qml
@@ -99,7 +99,7 @@ ColumnLayout {
         Layout.fillWidth: true
         text: qsTr("© 2014–%1 %2").arg(new Date().getFullYear()).arg(about.info.author)
         opacity: 0.55
-        font.pixelSize: 11
+        font.pixelSize: Theme.fsCaption
     }
 
     Label {
@@ -107,6 +107,6 @@ ColumnLayout {
         text: qsTr("Special thanks: Paul Tar Jr (Geiko) and Derrick D. Cochran.")
         wrapMode: Text.WordWrap
         opacity: 0.55
-        font.pixelSize: 11
+        font.pixelSize: Theme.fsCaption
     }
 }

--- a/l5r/qmlui/qml/sections/AdvancementsSection.qml
+++ b/l5r/qmlui/qml/sections/AdvancementsSection.qml
@@ -577,7 +577,7 @@ ColumnLayout {
                                 anchors.centerIn: parent
                                 text: qsTr("LATEST")
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 9
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.headingWeight
                                 font.letterSpacing: 2.0
                                 color: Theme.accent
@@ -613,7 +613,7 @@ ColumnLayout {
                                     Layout.fillWidth: true
                                     text: _meta.label.toUpperCase()
                                     font.family: Theme.fontDisplay
-                                    font.pixelSize: 9
+                                    font.pixelSize: Theme.fsMicro
                                     font.weight: Theme.headingWeight
                                     font.letterSpacing: 1.6
                                     horizontalAlignment: Text.AlignHCenter
@@ -693,7 +693,7 @@ ColumnLayout {
                                     Layout.fillWidth: true
                                     text: qsTr("XP")
                                     font.family: Theme.fontDisplay
-                                    font.pixelSize: 9
+                                    font.pixelSize: Theme.fsMicro
                                     font.weight: Theme.headingWeight
                                     font.letterSpacing: 2.0
                                     horizontalAlignment: Text.AlignRight

--- a/l5r/qmlui/qml/sections/KataSection.qml
+++ b/l5r/qmlui/qml/sections/KataSection.qml
@@ -323,7 +323,7 @@ ColumnLayout {
                         Layout.alignment: Qt.AlignHCenter
                         text: qsTr("MASTERY")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 8
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.5
                         color: card._ringColor
@@ -387,7 +387,7 @@ ColumnLayout {
                         Layout.fillWidth: true
                         text: card._cost
                         font.family: Theme.fontStat
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsStatMedium
                         font.weight: Theme.wMedium
                         font.features: Theme.tabularNumbers
                         horizontalAlignment: Text.AlignRight
@@ -397,7 +397,7 @@ ColumnLayout {
                         Layout.fillWidth: true
                         text: qsTr("XP")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 9
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 2.0
                         horizontalAlignment: Text.AlignRight

--- a/l5r/qmlui/qml/sections/KihoSection.qml
+++ b/l5r/qmlui/qml/sections/KihoSection.qml
@@ -150,7 +150,7 @@ ColumnLayout {
                         anchors.centerIn: parent
                         text: section._freeKiho === 1 ? qsTr("1 FREE") : qsTr("%1 FREE").arg(section._freeKiho)
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 10
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.2
                         color: Theme.whiteWash
@@ -358,7 +358,7 @@ ColumnLayout {
                         Layout.alignment: Qt.AlignHCenter
                         text: qsTr("MASTERY")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 8
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.5
                         color: card._ringColor
@@ -446,7 +446,7 @@ ColumnLayout {
                         Layout.fillWidth: true
                         text: card._cost
                         font.family: Theme.fontStat
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsStatMedium
                         font.weight: Theme.wMedium
                         font.features: Theme.tabularNumbers
                         horizontalAlignment: Text.AlignRight
@@ -456,7 +456,7 @@ ColumnLayout {
                         Layout.fillWidth: true
                         text: qsTr("XP")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 9
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 2.0
                         horizontalAlignment: Text.AlignRight

--- a/l5r/qmlui/qml/sections/MiscSection.qml
+++ b/l5r/qmlui/qml/sections/MiscSection.qml
@@ -400,7 +400,7 @@ ColumnLayout {
             Layout.alignment: Qt.AlignHCenter
             text: coinField.label.toUpperCase()
             font.family: Theme.fontDisplay
-            font.pixelSize: 9
+            font.pixelSize: Theme.fsMicro
             font.weight: Theme.wSemiBold
             font.letterSpacing: 1.4
             color: Theme.inkMuted
@@ -495,7 +495,7 @@ ColumnLayout {
                     anchors.centerIn: parent
                     text: qsTr("SCHOOL")
                     font.family: Theme.fontDisplay
-                    font.pixelSize: 9
+                    font.pixelSize: Theme.fsMicro
                     font.weight: Theme.wSemiBold
                     font.letterSpacing: 1.2
                     color: Theme.heading
@@ -692,7 +692,7 @@ ColumnLayout {
                     Layout.alignment: Qt.AlignRight
                     text: qsTr("VALUE")
                     font.family: Theme.fontDisplay
-                    font.pixelSize: 9
+                    font.pixelSize: Theme.fsMicro
                     font.weight: Theme.wSemiBold
                     font.letterSpacing: 1.2
                     color: Theme.inkMuted
@@ -716,7 +716,7 @@ ColumnLayout {
                     Layout.alignment: Qt.AlignHCenter
                     text: qsTr("APPLIED")
                     font.family: Theme.fontDisplay
-                    font.pixelSize: 9
+                    font.pixelSize: Theme.fsMicro
                     font.weight: Theme.wSemiBold
                     font.letterSpacing: 1.2
                     color: Theme.inkMuted

--- a/l5r/qmlui/qml/sections/PerksSection.qml
+++ b/l5r/qmlui/qml/sections/PerksSection.qml
@@ -195,11 +195,12 @@ ColumnLayout {
                         // always positive magnitude.
                         text: (parent._netCost ? "" : "+") + Math.abs(section._netXp)
                         font.family: Theme.fontStat
-                        // 44px is an intentional above-scale focal size for the
-                        // net-XP verdict (the centre of the "scale" metaphor);
-                        // the spec type scale tops out at fsStatLarge=36, so this
-                        // one stays a literal until/unless a hero token is added.
-                        font.pixelSize: 44
+                        // Above-scale focal size for the net-XP verdict (the
+                        // centre of the "scale" metaphor): larger than the
+                        // §3.2 ceiling fsStatLarge=36. Routed through the
+                        // dedicated fsHeroStat token so it scales with the
+                        // user's Text-size preference like the rest.
+                        font.pixelSize: Theme.fsHeroStat
                         font.weight: Theme.wSemiBold
                         font.features: Theme.tabularNumbers
                         horizontalAlignment: Text.AlignHCenter
@@ -480,7 +481,7 @@ ColumnLayout {
                         anchors.centerIn: parent
                         text: qsTr("%1 / %2 XP").arg(section._flawsXp).arg(section._flawsCap)
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 10
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 1.2
                         font.features: Theme.tabularNumbers
@@ -775,7 +776,7 @@ ColumnLayout {
                             anchors.centerIn: parent
                             text: card._categoryText
                             font.family: Theme.fontDisplay
-                            font.pixelSize: 10
+                            font.pixelSize: Theme.fsMicro
                             font.weight: Theme.headingWeight
                             font.letterSpacing: 1.2
                             color: card.accentColor
@@ -798,7 +799,7 @@ ColumnLayout {
                             anchors.centerIn: parent
                             text: qsTr("Rank %1").arg(card.item ? card.item.rank : 0)
                             font.family: Theme.fontDisplay
-                            font.pixelSize: 10
+                            font.pixelSize: Theme.fsMicro
                             font.weight: Theme.headingWeight
                             font.letterSpacing: 1.2
                             color: card.accentColor
@@ -857,7 +858,7 @@ ColumnLayout {
                     Layout.fillWidth: true
                     text: card._isFlaw && card._cost !== 0 ? "+" + card._cost : card._cost
                     font.family: Theme.fontDisplay
-                    font.pixelSize: 22
+                    font.pixelSize: Theme.fsStatMedium
                     font.weight: Font.Bold
                     font.features: Theme.tabularNumbers
                     horizontalAlignment: Text.AlignRight
@@ -868,7 +869,7 @@ ColumnLayout {
                     Layout.fillWidth: true
                     text: qsTr("XP")
                     font.family: Theme.fontDisplay
-                    font.pixelSize: 9
+                    font.pixelSize: Theme.fsMicro
                     font.weight: Theme.headingWeight
                     font.letterSpacing: 2.0
                     horizontalAlignment: Text.AlignRight

--- a/l5r/qmlui/qml/sections/SettingsSection.qml
+++ b/l5r/qmlui/qml/sections/SettingsSection.qml
@@ -261,6 +261,46 @@ ColumnLayout {
             RowLayout {
                 Layout.fillWidth: true
                 Label {
+                    text: qsTr("Text size")
+                    font.family: Theme.fontDisplay
+                    font.pixelSize: Theme.fsLabel
+                    font.weight: Theme.wSemiBold
+                    color: Theme.ink
+                    Layout.fillWidth: true
+                }
+                Widgets.L5RComboBox {
+                    id: fontSizeCombo
+                    Layout.preferredWidth: 260
+                    textRole: "name"
+                    model: appSettings ? appSettings.fontSizes : []
+                    Component.onCompleted: currentIndex = root.indexOfId(
+                        model, appSettings ? appSettings.fontSize : "standard")
+                    onActivated: function (i) {
+                        if (appSettings && model[i])
+                            appSettings.setFontSize(model[i].id);
+                    }
+                }
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: qsTr("Makes the sheet text larger and easier to read. Applies immediately.")
+                font.family: Theme.fontBody
+                font.pixelSize: Theme.fsCaption
+                font.italic: true
+                color: Theme.inkMuted
+                wrapMode: Text.WordWrap
+            }
+
+            Widgets.OrnateDivider {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.s2
+                Layout.bottomMargin: Theme.s2
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Label {
                     text: qsTr("Use the new interface")
                     font.family: Theme.fontDisplay
                     font.pixelSize: Theme.fsLabel

--- a/l5r/qmlui/qml/sections/SpellsSection.qml
+++ b/l5r/qmlui/qml/sections/SpellsSection.qml
@@ -414,7 +414,7 @@ ColumnLayout {
                         anchors.centerIn: parent
                         text: (modelData || "").toUpperCase()
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 10
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.2
                         color: leaning.accent
@@ -597,7 +597,7 @@ ColumnLayout {
                         Layout.alignment: Qt.AlignHCenter
                         text: qsTr("MASTERY")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 8
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.5
                         color: card._ringColor
@@ -702,7 +702,7 @@ ColumnLayout {
                                 anchors.centerIn: parent
                                 text: qsTr("MEMORIZED")
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 9
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.0
                                 color: Theme.inkMuted
@@ -721,7 +721,7 @@ ColumnLayout {
                         Layout.fillWidth: true
                         text: card._cost
                         font.family: Theme.fontStat
-                        font.pixelSize: 22
+                        font.pixelSize: Theme.fsStatMedium
                         font.weight: Theme.wMedium
                         font.features: Theme.tabularNumbers
                         horizontalAlignment: Text.AlignRight
@@ -731,7 +731,7 @@ ColumnLayout {
                         Layout.fillWidth: true
                         text: qsTr("XP")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 9
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.headingWeight
                         font.letterSpacing: 2.0
                         horizontalAlignment: Text.AlignRight
@@ -865,7 +865,7 @@ ColumnLayout {
                             Label {
                                 text: modelData.k
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 9
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.6
                                 color: Theme.heading
@@ -901,7 +901,7 @@ ColumnLayout {
                                 anchors.centerIn: parent
                                 text: (modelData || "").toUpperCase()
                                 font.family: Theme.fontDisplay
-                                font.pixelSize: 9
+                                font.pixelSize: Theme.fsMicro
                                 font.weight: Theme.wSemiBold
                                 font.letterSpacing: 1.0
                                 color: Theme.inkMuted

--- a/l5r/qmlui/qml/sections/TattooSection.qml
+++ b/l5r/qmlui/qml/sections/TattooSection.qml
@@ -314,7 +314,7 @@ ColumnLayout {
                         Layout.alignment: Qt.AlignHCenter
                         text: qsTr("MARK")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 8
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.5
                         color: section._mark

--- a/l5r/qmlui/qml/sections/TechniquesSection.qml
+++ b/l5r/qmlui/qml/sections/TechniquesSection.qml
@@ -274,7 +274,7 @@ ColumnLayout {
                         Layout.alignment: Qt.AlignHCenter
                         text: qsTr("INSIGHT")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 8
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.5
                         color: ClanTheme.primary
@@ -345,7 +345,7 @@ ColumnLayout {
                         anchors.centerIn: parent
                         text: qsTr("School Rank %1").arg(card._techRank)
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 10
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.2
                         color: ClanTheme.primary

--- a/l5r/qmlui/qml/sections/WeaponsSection.qml
+++ b/l5r/qmlui/qml/sections/WeaponsSection.qml
@@ -484,7 +484,7 @@ ColumnLayout {
             anchors.centerIn: parent
             text: badge.tag.toUpperCase()
             font.family: Theme.fontDisplay
-            font.pixelSize: 9
+            font.pixelSize: Theme.fsMicro
             font.weight: Theme.wSemiBold
             font.letterSpacing: 1.0
             color: badge._c
@@ -507,7 +507,7 @@ ColumnLayout {
         Label {
             text: label.toUpperCase()
             font.family: Theme.fontDisplay
-            font.pixelSize: 9
+            font.pixelSize: Theme.fsMicro
             font.weight: Theme.wSemiBold
             font.letterSpacing: 1.2
             color: Theme.inkMuted
@@ -955,7 +955,7 @@ ColumnLayout {
                         Layout.alignment: Qt.AlignHCenter
                         text: qsTr("QUANTITY")
                         font.family: Theme.fontDisplay
-                        font.pixelSize: 9
+                        font.pixelSize: Theme.fsMicro
                         font.weight: Theme.wSemiBold
                         font.letterSpacing: 1.2
                         color: Theme.inkMuted

--- a/l5r/qmlui/qml/widgets/RingCard.qml
+++ b/l5r/qmlui/qml/widgets/RingCard.qml
@@ -78,7 +78,7 @@ Rectangle {
                     color: "white"
                     font.family: Theme.fontDisplay
                     font.weight: Theme.headingWeight
-                    font.pixelSize: 15
+                    font.pixelSize: Theme.fsHeading2
                     font.letterSpacing: 1.2
                     Layout.fillWidth: true
                     elide: Text.ElideRight

--- a/l5r/qmlui/qml/widgets/SheetSidebar.qml
+++ b/l5r/qmlui/qml/widgets/SheetSidebar.qml
@@ -84,7 +84,7 @@ Rectangle {
                 Layout.fillWidth: true
                 text: (pcProxy && pcProxy.name) ? pcProxy.name : qsTr("Unnamed")
                 font.family: Theme.fontDisplay
-                font.pixelSize: 17
+                font.pixelSize: Theme.fsHeading1
                 font.weight: Font.DemiBold
                 font.letterSpacing: 0.5
                 color: Theme.heading
@@ -194,7 +194,7 @@ Rectangle {
                     }
                     Label {
                         text: modelData.title
-                        font.pixelSize: 12
+                        font.pixelSize: Theme.fsBodySmall
                         Layout.fillWidth: true
                         elide: Text.ElideRight
                         color: tocDelegate.highlighted ? ClanTheme.primary : palette.windowText

--- a/l5r/qmlui/qml/widgets/SheetSidebar.qml
+++ b/l5r/qmlui/qml/widgets/SheetSidebar.qml
@@ -1,0 +1,266 @@
+// Copyright (C) 2014-2026 Daniele Simonetti
+// Navigation sidebar: the character identity block above a table-of-
+// contents list of every section. Extracted from MainSheet so the SAME
+// content can be hosted in two places depending on window width
+// (design system §4.4 responsive layout):
+//   - wide  : pinned in the main RowLayout as a fixed 220px column;
+//   - compact: inside a left-edge Drawer opened by the top-bar hamburger.
+//
+// The component is stateless about *which* section is current: the owner
+// drives `currentIndex` (one-way) and listens to `sectionActivated(index)`
+// for navigable clicks, so both hosted instances stay in lockstep with a
+// single source of truth in MainSheet. The Qt context properties
+// (pcProxy / appCtrl) are read directly -- they are global to every QML
+// file in this UI.
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Theme 1.0
+import ClanTheme 1.0
+
+Rectangle {
+    id: sidebar
+
+    // Driven by the owner; flows to the ListView's currentIndex (one-way).
+    property int currentIndex: 0
+    // Emitted when a *navigable* (non-hidden) row is clicked. The owner
+    // scrolls the sheet and, in compact mode, closes the drawer.
+    signal sectionActivated(int index)
+
+    // Slightly darker parchment than the main sheet so the navigation
+    // column reads as a distinct zone without breaking the "one document"
+    // illusion.
+    color: ClanTheme.paperSidebar
+
+    // Ink-on-parchment palette, self-contained. The fixed-sidebar host
+    // (MainSheet's Pane) sets these and they descend to children, but the
+    // drawer host is a Popup -- a separate palette root that does NOT
+    // inherit the Pane's overrides -- so labels reading palette.windowText
+    // would otherwise fall back to the system colours there. Declaring the
+    // overrides on the component itself makes it render correctly in both
+    // hosts (the same defensive pattern as SheetPanel).
+    palette.windowText: Theme.ink
+    palette.text: Theme.ink
+    palette.buttonText: Theme.ink
+    palette.base: Theme.parchmentBase
+    palette.alternateBase: Theme.parchmentInset
+    palette.placeholderText: Theme.inkFaint
+    palette.mid: Theme.inkFaint
+
+    // Per-character section visibility (the sidebar eye / View menu).
+    // Both read appCtrl's notifyable lists, so every binding that calls
+    // them re-evaluates when hiddenSectionsChanged fires.
+    function sectionHidden(id) {
+        return appCtrl ? appCtrl.hiddenSections.indexOf(id) >= 0 : false;
+    }
+    function sectionFixed(id) {
+        return appCtrl ? appCtrl.fixedSections.indexOf(id) >= 0 : false;
+    }
+
+    // Same fibre texture as the main sheet so the sidebar reads as the
+    // same paper, just a darker shade -- not a flat coloured panel glued
+    // onto the document.
+    RicePaperOverlay {
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.topMargin: 14
+        anchors.bottomMargin: 8
+        anchors.leftMargin: 10
+        anchors.rightMargin: 10
+        spacing: 6
+
+        // ---- Identity block ----------------------------------
+        // Three-line character header above the TOC: name in burnt-gold
+        // display type, clan + rank as a single secondary line, school
+        // italicised underneath. Reads like the title block of a
+        // character sheet rather than a piece of chrome.
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 1
+
+            Label {
+                Layout.fillWidth: true
+                text: (pcProxy && pcProxy.name) ? pcProxy.name : qsTr("Unnamed")
+                font.family: Theme.fontDisplay
+                font.pixelSize: 17
+                font.weight: Font.DemiBold
+                font.letterSpacing: 0.5
+                color: Theme.heading
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignHCenter
+            }
+            Label {
+                Layout.fillWidth: true
+                readonly property string _clan: (pcProxy && pcProxy.clan) ? pcProxy.clan : ""
+                readonly property int _rank: pcProxy ? pcProxy.progression.rank : 0
+                text: {
+                    var clanFmt = _clan ? _clan.charAt(0).toUpperCase() + _clan.slice(1) : qsTr("No Clan");
+                    return clanFmt + " — " + qsTr("Rank %1").arg(_rank);
+                }
+                font.pixelSize: Theme.fsBody
+                font.features: Theme.tabularNumbers
+                color: palette.windowText
+                opacity: 0.85
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignHCenter
+            }
+            Label {
+                Layout.fillWidth: true
+                text: (pcProxy && pcProxy.school) ? pcProxy.school : qsTr("No School")
+                font.pixelSize: Theme.fsCaption
+                font.italic: true
+                color: palette.windowText
+                opacity: 0.7
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+
+        OrnateDivider {
+            Layout.fillWidth: true
+            Layout.topMargin: 4
+            Layout.bottomMargin: 2
+        }
+
+        ListView {
+            id: toc
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: appCtrl ? appCtrl.tabs : []
+            clip: true
+            currentIndex: sidebar.currentIndex
+            spacing: 2
+            interactive: true
+            boundsBehavior: Flickable.StopAtBounds
+
+            delegate: ItemDelegate {
+                id: tocDelegate
+                width: ListView.view.width
+                height: 38
+                highlighted: ListView.isCurrentItem
+                // Re-evaluate when appCtrl.hiddenSections changes.
+                readonly property bool sectionIsHidden: sidebar.sectionHidden(modelData.id)
+                readonly property bool sectionIsFixed: sidebar.sectionFixed(modelData.id)
+                onClicked: {
+                    // A hidden row is inert, like a disabled control:
+                    // clicking its body does nothing. Only the eye toggle
+                    // brings it back.
+                    if (tocDelegate.sectionIsHidden)
+                        return;
+                    sidebar.sectionActivated(index);
+                }
+
+                // Strip the default Control background -- without this
+                // override, ItemDelegate paints a palette-driven fill that
+                // reads as flat grey on top of the parchment sidebar. Hover
+                // gets a warm wash (lighter parchment), idle is fully
+                // transparent so the sidebar texture shows through.
+                background: Rectangle {
+                    // No hover wash on a hidden row -- it's inert, so it
+                    // shouldn't invite a click (the eye has its own hover
+                    // feedback).
+                    color: (tocDelegate.hovered && !tocDelegate.sectionIsHidden) ? Qt.lighter(ClanTheme.paperSidebar, 1.07) : "transparent"
+                }
+
+                // Active item: accent stripe on the left, accent icon,
+                // accent-tinted label. Inactive: normal palette text
+                // colours so the OS theme is honoured.
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    width: 3
+                    color: ClanTheme.primary
+                    visible: tocDelegate.highlighted
+                }
+                contentItem: RowLayout {
+                    spacing: 10
+                    // Brush-script kanji; the Hakushū Higerei face has
+                    // heavier strokes than a system CJK font so 20px is
+                    // comfortable here without crowding the column.
+                    Label {
+                        text: modelData.icon
+                        font.family: Theme.fontKanji
+                        font.pixelSize: 22
+                        Layout.leftMargin: 14
+                        Layout.preferredWidth: 28
+                        horizontalAlignment: Text.AlignHCenter
+                        color: tocDelegate.highlighted ? ClanTheme.primary : palette.windowText
+                        // Dim a hidden section's row so it reads as "off"
+                        // yet stays available to re-show.
+                        opacity: tocDelegate.sectionIsHidden ? 0.35 : (tocDelegate.highlighted ? 1.0 : 0.7)
+                    }
+                    Label {
+                        text: modelData.title
+                        font.pixelSize: 12
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        color: tocDelegate.highlighted ? ClanTheme.primary : palette.windowText
+                        font.weight: tocDelegate.highlighted ? Font.DemiBold : Font.Normal
+                        opacity: tocDelegate.sectionIsHidden ? 0.35 : 1.0
+                    }
+
+                    // Opportunity badge -- a count of pending "you unlocked
+                    // something" actions resolved in this section (free kiho
+                    // today; granted skills / spells / rank-up as those
+                    // flows are ported). Accent-blue per the §6.16
+                    // positive-action language -- crimson is reserved for
+                    // destructive/unmet, so this reads as an invitation,
+                    // not an alarm.
+                    Rectangle {
+                        readonly property int _count: (pcProxy && pcProxy.opportunityBadges && pcProxy.opportunityBadges[modelData.id] !== undefined) ? pcProxy.opportunityBadges[modelData.id] : 0
+                        visible: _count > 0
+                        Layout.rightMargin: 12
+                        Layout.alignment: Qt.AlignVCenter
+                        implicitWidth: Math.max(18, badgeCount.implicitWidth + 10)
+                        implicitHeight: 18
+                        radius: 9
+                        color: Theme.secondary
+                        Label {
+                            id: badgeCount
+                            anchors.centerIn: parent
+                            text: parent._count
+                            font.family: Theme.fontStat
+                            font.pixelSize: Theme.fsCaption
+                            font.weight: Theme.wSemiBold
+                            font.features: Theme.tabularNumbers
+                            color: Theme.whiteWash
+                        }
+                    }
+
+                    // Visibility toggle: a brush 見 ("view") glyph, matching
+                    // the kanji section icons. Shown on hover, or always
+                    // while the row is hidden so it can be brought back.
+                    // Never on the fixed sections (pc_info / about).
+                    ToolButton {
+                        id: eyeBtn
+                        visible: !tocDelegate.sectionIsFixed && (tocDelegate.hovered || tocDelegate.sectionIsHidden)
+                        Layout.rightMargin: 12
+                        Layout.alignment: Qt.AlignVCenter
+                        implicitWidth: 22
+                        implicitHeight: 22
+                        padding: 0
+                        background: Rectangle {
+                            radius: 4
+                            color: eyeBtn.hovered ? Qt.lighter(ClanTheme.paperSidebar, 1.12) : "transparent"
+                        }
+                        contentItem: Label {
+                            text: "見"
+                            font.family: Theme.fontKanji
+                            font.pixelSize: 15
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            color: tocDelegate.highlighted ? ClanTheme.primary : palette.windowText
+                            opacity: tocDelegate.sectionIsHidden ? 0.9 : (eyeBtn.hovered ? 1.0 : 0.5)
+                        }
+                        onClicked: appCtrl.setSectionHidden(modelData.id, !tocDelegate.sectionIsHidden)
+                        ToolTip.visible: hovered
+                        ToolTip.text: tocDelegate.sectionIsHidden ? qsTr("Show section") : qsTr("Hide section")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/l5r/util/settings.py
+++ b/l5r/util/settings.py
@@ -262,6 +262,10 @@ class L5RCMSettings_App(object):
     def use_system_locale(self):
         return _is_true(self._qsettings.value('use_machine_locale', True))
 
+    @property
+    def ui_font_size(self):
+        return self._qsettings.value('ui_font_size', 'standard')
+
     # setter
     @health_method.setter
     def health_method(self, value):
@@ -306,3 +310,7 @@ class L5RCMSettings_App(object):
     @user_locale.setter
     def user_locale(self, value):
         self._qsettings.setValue('user_locale', value)
+
+    @ui_font_size.setter
+    def ui_font_size(self, value):
+        self._qsettings.setValue('ui_font_size', value)


### PR DESCRIPTION
## Summary

Two related QML-UI improvements for the parchment sheet, bundled into one PR.

### 1. Responsive main-window layout (`67cd6d2`)
Below the compact breakpoint the nav sidebar collapses behind a hamburger drawer and a slim top app-bar appears, so the sheet stays usable on narrow/phone-portrait widths while tablet/desktop keep the fixed sidebar.

### 2. User-selectable UI text size (`9a6fc17`)
Addresses user reports that the new UI fonts are too small. Adds a **"Text size"** preference (Standard / Large / Larger / Huge → 1.0 / 1.15 / 1.25 / 1.45) in *Settings → Interface*.

- **Theme**: new writable `fontScale` multiplier; the §3.2 `fs*` tokens become `Math.round(base * fontScale)`. Added the sub-caption tokens the dense list rows needed (`fsBodySmall` 12, `fsMicro` 10) and a `fsHeroStat` (44) for the Perks net-XP focal numeral — all scalable.
- **Persistence**: `app.ui_font_size` via `L5RCMSettings`; `SettingsProxy` exposes `fontSize` / `fontScale` / `fontSizes` and a `setFontSize` slot.
- **Live apply**: `MainSheet` binds `Theme.fontScale` to `appSettings.fontScale` (no restart).
- **Coverage**: migrated every *readable* hard-coded `pixelSize` across sections, dialogs and shared widgets (sidebar nav, ring labels, list captions, costs, XP/mastery micro-labels, dialog titles) onto the scalable tokens. Decorative kanji/watermarks and symbolic glyphs (`± ✕ ✎ ▲ ▼` carets) stay fixed by design.

## Test plan
- Open *Settings → Interface → Text size*, switch between the choices: sheet text (sidebar, lists, costs, dialogs) rescales immediately; kanji/watermarks unchanged.
- Restart the app — the choice persists (`ui_font_size` in QSettings).
- Scroll dense sections (Skills/Perks/Spells) and a couple of *Buy…* dialogs at the largest size to check for overflow.
- Resize the window below/above the compact breakpoint to verify the drawer ⇄ fixed-sidebar transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)