### PR TITLE
Origin as a stat grid + Different School support

### DIFF
--- a/l5r/api/character/__init__.py
+++ b/l5r/api/character/__init__.py
@@ -715,7 +715,7 @@ def clear_origin():
     set_dirty_flag(True)
 
 
-def set_origin(family_id, school_id, path_id=None):
+def set_origin(family_id, school_id, path_id=None, buy_different_school=False):
     """Atomically (re)set the character's whole origin: family (+ clan) and
     starting school (+ optional rank-1 path).
 
@@ -724,7 +724,12 @@ def set_origin(family_id, school_id, path_id=None):
     bonuses must not change after a rank has been bought against them
     (issue #448) -- and otherwise replaces any previous origin wholesale via
     clear_origin(). Owns the dirty flag and emits character_refreshed so every
-    binding re-projects. Returns True on success, False if frozen."""
+    binding re-projects. Returns True on success, False if frozen.
+
+    When ``buy_different_school`` is set (the school comes from a clan other
+    than the family's), the 'Different School' advantage is purchased at its
+    full rulebook cost as part of the same atomic commit -- so the origin then
+    freezes (xp() > 0), matching the legacy FirstSchoolChooserDialog."""
     pc = get_context().pc
     if not pc:
         return False
@@ -738,6 +743,12 @@ def set_origin(family_id, school_id, path_id=None):
         set_family(family_id)
     if school_id:
         api.character.schools.set_first_with_path(school_id, path_id)
+    # Purchased after the school is set so can_buy_advancements() passes
+    # (the origin is now complete). Full cost, so this is what tips xp()
+    # above zero and freezes the origin afterwards.
+    if buy_different_school:
+        from l5r.api.character import merits as _merits
+        _merits.add('different_school')
 
     set_dirty_flag(True)
     l5r.api.signals.bus().character_refreshed.emit()

--- a/l5r/qmlui/proxies/app_controller.py
+++ b/l5r/qmlui/proxies/app_controller.py
@@ -1643,6 +1643,15 @@ class AppController(QObject):
         cost overrides)."""
         if not rule_id:
             return
+        # Origin must be chosen before any merit/flaw is recorded -- this
+        # path appends the advancement directly (bypassing
+        # purchase_advancement's gate), so enforce it here and nudge with the
+        # same toast the trait/skill purchases use (#448/#450). Without this a
+        # player could buy an advantage first, spend XP, and freeze themselves
+        # out of the (now hidden) "Choose Origin" button.
+        if not api.character.can_buy_advancements():
+            self._purchase_blocked(CMErrors.MISSING_ORIGIN)
+            return
         is_flaw = kind == "flaw"
 
         if is_flaw:
@@ -2246,6 +2255,25 @@ class AppController(QObject):
         return [_school_record(s)
                 for s in sorted(base, key=lambda x: x.name)]
 
+    @Slot(result=int)
+    def differentSchoolCost(self):
+        """XP cost of the rank-1 'Different School' advantage, for the Origin
+        dialog's cross-clan note. 0 if the datapack doesn't define it."""
+        try:
+            return abs(int(api.data.merits.get_rank_cost('different_school', 1) or 0))
+        except Exception:
+            return 0
+
+    @Slot(str, result=str)
+    def clanOfSchool(self, school_id):
+        """Clan id that owns ``school_id`` (empty if unknown). Lets the Origin
+        dialog detect a cross-clan starting school on reopen and pre-arm its
+        'Different School' mode."""
+        if not school_id:
+            return ""
+        s = api.data.schools.get(school_id)
+        return (getattr(s, "clanid", "") or "") if s else ""
+
     @Slot(str, result="QVariantList")
     def rank1PathsForClan(self, clan_id):
         paths = api.data.schools.get_paths_with_rank(1)
@@ -2273,16 +2301,19 @@ class AppController(QObject):
         advancement count -- issue #448). Mirrors PcProxy.identity.canEditOrigin."""
         return bool(api.character.model() and api.character.can_edit_origin())
 
-    @Slot(str, str, str)
-    def setOrigin(self, family_id, school_id, path_id):
+    @Slot(str, str, str, bool)
+    def setOrigin(self, family_id, school_id, path_id, different_school=False):
         """Commit the whole origin (clan via family, first school, optional
         rank-1 path) in one atomic step -- the unified OriginSelectionDialog
         (#451). Delegates to api.character.set_origin, which replaces any
         previous origin while editable and refuses once XP is spent (#448).
+        ``different_school`` buys the Different School advantage when the school
+        comes from a clan other than the family's (#451).
         notify_character_refreshed is fired by set_origin on success."""
         if not school_id and not family_id:
             return
-        api.character.set_origin(family_id, school_id, path_id or None)
+        api.character.set_origin(family_id, school_id, path_id or None,
+                                 buy_different_school=bool(different_school))
 
     # --- startup hooks ------------------------------------------------
 

--- a/l5r/qmlui/qml/dialogs/OriginSelectionDialog.qml
+++ b/l5r/qmlui/qml/dialogs/OriginSelectionDialog.qml
@@ -35,36 +35,61 @@ Widgets.L5RDialog {
     acceptEnabled: _selectedFamilyId.length > 0 && _selectedSchoolId.length > 0
 
     // Working state, separate from the model until Accept fires.
-    property string _selectedClanId: ""
+    property string _selectedClanId: ""        // family's clan
     property string _selectedFamilyId: ""
+    property string _selectedSchoolClanId: ""  // school's clan (== family's unless Different School)
     property string _selectedSchoolId: ""
     property string _selectedPathId: ""
+    // Different School: the starting school comes from a clan other than the
+    // family's. Unlocks the School-clan combo and buys the advantage on Accept.
+    property bool _differentSchool: false
     property var _families: []
     property var _schools: []
     property var _paths: []
+    readonly property int _differentSchoolCost: appCtrl ? appCtrl.differentSchoolCost() : 0
+    // True when the chosen school's clan actually differs from the family's --
+    // the condition that makes the Different School advantage due.
+    readonly property bool _isCrossClan: _selectedSchoolClanId !== _selectedClanId
 
     onAboutToShow: {
         _selectedClanId = appCtrl ? appCtrl.currentClanId() : "";
         _selectedFamilyId = appCtrl ? appCtrl.currentFamilyId() : "";
         _selectedSchoolId = appCtrl ? appCtrl.currentFirstSchoolId() : "";
+        // Pre-arm Different School when the saved school is from another clan
+        // (kept robust even though a frozen cross-clan origin is rarely reopened).
+        var schoolClan = (appCtrl && _selectedSchoolId) ? appCtrl.clanOfSchool(_selectedSchoolId) : "";
+        _selectedSchoolClanId = schoolClan || _selectedClanId;
+        _differentSchool = (_selectedSchoolId.length > 0 && schoolClan.length > 0 && schoolClan !== _selectedClanId);
         _selectedPathId = "";
         _refreshLists();
+        // Explicit sync: the toggle's `checked` binding is severed the first
+        // time the user flips it, so re-assert it on each open.
+        differentSchoolToggle.checked = _differentSchool;
         _syncClanCombo();
         _syncFamilyCombo();
+        _syncSchoolClanCombo();
         _syncSchoolCombo();
         pathCombo.currentIndex = 0;
     }
 
     onAccepted: {
         if (appCtrl && _selectedFamilyId && _selectedSchoolId) {
-            appCtrl.setOrigin(_selectedFamilyId, _selectedSchoolId, _selectedPathId);
+            // Buy the advantage only when the school truly is from another clan.
+            appCtrl.setOrigin(_selectedFamilyId, _selectedSchoolId,
+                              _selectedPathId, root._isCrossClan);
         }
+    }
+
+    // Effective clan the school list / paths are drawn from.
+    function _effectiveSchoolClan() {
+        return _differentSchool ? _selectedSchoolClanId : _selectedClanId;
     }
 
     function _refreshLists() {
         _families = appCtrl ? appCtrl.familiesForClan(_selectedClanId) : [];
-        _schools = appCtrl ? appCtrl.basicSchoolsForClan(_selectedClanId) : [];
-        _paths = appCtrl ? appCtrl.rank1PathsForClan(_selectedClanId) : [];
+        var schoolClan = _effectiveSchoolClan();
+        _schools = appCtrl ? appCtrl.basicSchoolsForClan(schoolClan) : [];
+        _paths = appCtrl ? appCtrl.rank1PathsForClan(schoolClan) : [];
     }
 
     function _syncClanCombo() {
@@ -76,6 +101,17 @@ Widgets.L5RDialog {
             }
         }
         clanCombo.currentIndex = idx >= 0 ? idx : 0;
+    }
+
+    function _syncSchoolClanCombo() {
+        var idx = -1;
+        for (var i = 0; i < schoolClanCombo.count; ++i) {
+            if (schoolClanCombo.model[i].id === _selectedSchoolClanId) {
+                idx = i;
+                break;
+            }
+        }
+        schoolClanCombo.currentIndex = idx >= 0 ? idx : 0;
     }
 
     function _syncFamilyCombo() {
@@ -150,8 +186,13 @@ Widgets.L5RDialog {
             onActivated: function (index) {
                 var rec = clanCombo.model[index];
                 root._selectedClanId = rec ? rec.id : "";
+                // While not in Different School mode the school follows the
+                // family's clan; keep the two in lock-step.
+                if (!root._differentSchool)
+                    root._selectedSchoolClanId = root._selectedClanId;
                 root._refreshLists();
                 root._syncFamilyCombo();
+                root._syncSchoolClanCombo();
                 root._syncSchoolCombo();
                 pathCombo.currentIndex = 0;
                 root._selectedPathId = "";
@@ -170,6 +211,58 @@ Widgets.L5RDialog {
             onActivated: function (index) {
                 var rec = root._families[index];
                 root._selectedFamilyId = rec ? rec.id : "";
+            }
+        }
+
+        // Different School advantage: lets the starting school come from a
+        // clan other than the family's. The all-clans school list would be
+        // dozens long, so we keep the per-clan School combo and add a second
+        // clan combo here (mirrors the legacy FirstSchoolChooserDialog).
+        Label {
+            text: qsTr("Different School:")
+        }
+        Widgets.L5RToggle {
+            id: differentSchoolToggle
+            checked: root._differentSchool
+            onToggled: {
+                root._differentSchool = checked;
+                // Default the school clan to the family's when turning the
+                // option off (or on for the first time).
+                if (!checked || !root._selectedSchoolClanId)
+                    root._selectedSchoolClanId = root._selectedClanId;
+                root._refreshLists();
+                root._syncSchoolClanCombo();
+                root._syncSchoolCombo();
+                pathCombo.currentIndex = 0;
+                root._selectedPathId = "";
+            }
+        }
+
+        // School-clan combo -- only shown in Different School mode.
+        Label {
+            text: qsTr("School Clan:")
+            visible: root._differentSchool
+        }
+        Widgets.L5RComboBox {
+            id: schoolClanCombo
+            Layout.fillWidth: true
+            visible: root._differentSchool
+            textRole: "name"
+            accent: root.accent
+            model: {
+                var clans = appCtrl ? appCtrl.clansList() : [];
+                return [{
+                        "id": "",
+                        "name": qsTr("No Clan")
+                    }].concat(clans);
+            }
+            onActivated: function (index) {
+                var rec = schoolClanCombo.model[index];
+                root._selectedSchoolClanId = rec ? rec.id : "";
+                root._refreshLists();
+                root._syncSchoolCombo();
+                pathCombo.currentIndex = 0;
+                root._selectedPathId = "";
             }
         }
 
@@ -239,6 +332,21 @@ Widgets.L5RDialog {
             Layout.fillWidth: true
             color: Theme.positive
             text: root._bonusText()
+        }
+
+        // Cross-clan advisory: explains the XP that Accept will spend and
+        // that the origin freezes afterwards (the advantage costs XP).
+        Label {
+            Layout.columnSpan: 2
+            Layout.fillWidth: true
+            visible: root._isCrossClan
+            wrapMode: Text.WordWrap
+            font.italic: true
+            font.pixelSize: Theme.fsCaption
+            color: Theme.accent
+            text: root._differentSchoolCost > 0
+                  ? qsTr("A school outside your clan requires the Different School advantage (−%1 XP). The origin locks once accepted.").arg(root._differentSchoolCost)
+                  : qsTr("A school outside your clan requires the Different School advantage. The origin locks once accepted.")
         }
     }
 }

--- a/l5r/qmlui/qml/sections/CharacterSection.qml
+++ b/l5r/qmlui/qml/sections/CharacterSection.qml
@@ -53,26 +53,6 @@ ColumnLayout {
     function _traitLabel(traitId) {
         return traitId ? (section._attrLabels[traitId] || traitId) : "";
     }
-    function _originSummary() {
-        if (!pcProxy)
-            return "";
-        var parts = [];
-        if (pcProxy.clan)
-            parts.push(pcProxy.clan);
-        if (pcProxy.family)
-            parts.push(pcProxy.family);
-        if (pcProxy.school)
-            parts.push(pcProxy.school);
-        return parts.join("   ·   ");
-    }
-    function _originBonuses() {
-        var parts = [];
-        if (section._familyTrait)
-            parts.push(qsTr("+1 %1").arg(section._traitLabel(section._familyTrait)));
-        if (section._schoolTrait)
-            parts.push(qsTr("+1 %1").arg(section._traitLabel(section._schoolTrait)));
-        return parts.join("   ·   ");
-    }
 
     // A pending rank-up (the root opportunity -- every grant flows from
     // it). Drives the callout below; the matching TOC badge comes from the
@@ -129,6 +109,58 @@ ColumnLayout {
             "key": "infamy",
             "label": qsTr("Infamy")
         }]
+
+    // Shared stat-strip primitives -- used by both the Origin grid and
+    // the progression strip below so the two read as one ledger.
+    component StatCell: ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 1
+        property alias caption: capLabel.text
+        // Optional bonus/footnote rendered under the value (e.g. the
+        // origin "+1 <trait>" starting bonus). Empty for plain cells.
+        property alias subCaption: subLabel.text
+        default property alias cellData: valueHolder.data
+        Label {
+            id: capLabel
+            font.family: Theme.fontDisplay
+            font.pixelSize: Theme.fsCaption
+            font.weight: Theme.wSemiBold
+            font.letterSpacing: 1.2
+            color: Theme.inkMuted
+        }
+        RowLayout {
+            id: valueHolder
+            Layout.fillWidth: true
+            spacing: 6
+        }
+        Label {
+            id: subLabel
+            Layout.fillWidth: true
+            visible: text.length > 0
+            color: Theme.positive
+            font.family: Theme.fontBody
+            font.pixelSize: Theme.fsCaption
+            elide: Text.ElideRight
+        }
+    }
+
+    component StatValue: Label {
+        font.family: Theme.fontStat
+        font.pixelSize: Theme.fsStatMedium
+        font.weight: Theme.wMedium
+        font.features: Theme.tabularNumbers
+        color: Theme.heading
+        elide: Text.ElideRight
+    }
+
+    component StatDivider: Rectangle {
+        Layout.preferredWidth: 1
+        Layout.fillHeight: true
+        Layout.topMargin: 2
+        Layout.bottomMargin: 2
+        color: Theme.divider
+        opacity: Theme.dividerOpacity
+    }
 
     Dialogs.OriginSelectionDialog {
         id: originDlg
@@ -274,7 +306,9 @@ ColumnLayout {
         }
     }
 
-    // Origin summary line + single edit/choose action
+    // Origin grid -- Clan | Family | School as a stat strip mirroring the
+    // progression strip below, plus a single edit/choose action and the
+    // starting-bonus caption underneath.
     ColumnLayout {
         Layout.fillWidth: true
         Layout.topMargin: 4
@@ -282,21 +316,38 @@ ColumnLayout {
 
         RowLayout {
             Layout.fillWidth: true
-            spacing: 10
+            spacing: 14
 
-            Label {
-                // Same plain styling as the "Name" label above (default
-                // font/colour), per design feedback.
-                text: qsTr("Origin")
-                Layout.alignment: Qt.AlignVCenter
+            StatCell {
+                caption: qsTr("CLAN")
+                StatValue {
+                    Layout.fillWidth: true
+                    text: (pcProxy && pcProxy.clan) ? pcProxy.clan : qsTr("—")
+                    color: (pcProxy && pcProxy.clan) ? Theme.heading : Theme.inkFaint
+                    font.italic: !(pcProxy && pcProxy.clan)
+                }
             }
-            Label {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                text: section._originComplete ? section._originSummary() : qsTr("— not chosen —")
-                color: section._originComplete ? Theme.heading : Theme.inkFaint
-                font.italic: !section._originComplete
-                elide: Text.ElideRight
+            StatDivider {}
+            StatCell {
+                caption: qsTr("FAMILY")
+                subCaption: section._familyTrait ? qsTr("+1 %1").arg(section._traitLabel(section._familyTrait)) : ""
+                StatValue {
+                    Layout.fillWidth: true
+                    text: (pcProxy && pcProxy.family) ? pcProxy.family : qsTr("—")
+                    color: (pcProxy && pcProxy.family) ? Theme.heading : Theme.inkFaint
+                    font.italic: !(pcProxy && pcProxy.family)
+                }
+            }
+            StatDivider {}
+            StatCell {
+                caption: qsTr("SCHOOL")
+                subCaption: section._schoolTrait ? qsTr("+1 %1").arg(section._traitLabel(section._schoolTrait)) : ""
+                StatValue {
+                    Layout.fillWidth: true
+                    text: (pcProxy && pcProxy.school) ? pcProxy.school : qsTr("—")
+                    color: (pcProxy && pcProxy.school) ? Theme.heading : Theme.inkFaint
+                    font.italic: !(pcProxy && pcProxy.school)
+                }
             }
             Widgets.L5RButton {
                 // Filled CTA while unset (the first thing a new character
@@ -315,13 +366,6 @@ ColumnLayout {
                 onClicked: originDlg.open()
             }
         }
-        Label {
-            visible: section._originComplete && text.length > 0
-            text: section._originBonuses()
-            color: Theme.positive
-            font.family: Theme.fontBody
-            font.pixelSize: Theme.fsCaption
-        }
     }
 
     // Progression stat strip — Rank | Insight | Exp Points
@@ -329,44 +373,6 @@ ColumnLayout {
         Layout.fillWidth: true
         Layout.topMargin: 4
         spacing: 14
-
-        component StatCell: ColumnLayout {
-            Layout.fillWidth: true
-            spacing: 1
-            property alias caption: capLabel.text
-            default property alias cellData: valueHolder.data
-            Label {
-                id: capLabel
-                font.family: Theme.fontDisplay
-                font.pixelSize: Theme.fsCaption
-                font.weight: Theme.wSemiBold
-                font.letterSpacing: 1.2
-                color: Theme.inkMuted
-            }
-            RowLayout {
-                id: valueHolder
-                Layout.fillWidth: true
-                spacing: 6
-            }
-        }
-
-        component StatValue: Label {
-            font.family: Theme.fontStat
-            font.pixelSize: Theme.fsStatMedium
-            font.weight: Theme.wMedium
-            font.features: Theme.tabularNumbers
-            color: Theme.heading
-            elide: Text.ElideRight
-        }
-
-        component StatDivider: Rectangle {
-            Layout.preferredWidth: 1
-            Layout.fillHeight: true
-            Layout.topMargin: 2
-            Layout.bottomMargin: 2
-            color: Theme.divider
-            opacity: Theme.dividerOpacity
-        }
 
         StatCell {
             caption: qsTr("RANK")

--- a/l5r/qmlui/tests/test_app_controller.py
+++ b/l5r/qmlui/tests/test_app_controller.py
@@ -322,3 +322,13 @@ class TestOriginController(unittest.TestCase):
         self.assertEqual('test_family_1', api.character.get_family())
         self.assertEqual('test_school_1', api.character.schools.get_first())
         self.assertEqual(1, len(api.character.rankadv.get_all()))
+
+    def test_inscribePerk_before_origin_is_refused_with_notice(self):
+        """Merits/flaws must not be recorded before the origin is chosen --
+        this path appends directly (bypassing purchase_advancement's gate), so
+        it must enforce the same rule and nudge with a toast (#448/#450)."""
+        notices = []
+        self.ctrl.notice.connect(lambda m: notices.append(m))
+        self.ctrl.inscribePerk('merit', 'test_merit_1', 1, '', -1)
+        self.assertEqual(1, len(notices))
+        self.assertEqual([], api.character.model().advans)


### PR DESCRIPTION
Closes #453.

## Character section: origin as a stat grid
The single "Clan · Family · School" summary line becomes a stat strip mirroring the Rank / Insight / XP progression strip below it, so the two read as one ledger. Each cell shows its starting `+1 <trait>` bonus underneath (family bonus under FAMILY, school bonus under SCHOOL). Shared `StatCell`/`StatValue`/`StatDivider` primitives hoisted to section scope.

## Origin dialog fixes (from a user report)
1. **Different School.** The dialog tied clan → family → school to a single clan, so the starting school could only come from the family's clan. Added a "Different School" toggle that reveals a second "School Clan" combo (kept per-clan, not a flat all-schools list which would be dozens long). When the chosen school's clan differs from the family's, `set_origin` buys the Different School advantage at full cost — so the origin then freezes, matching the legacy `FirstSchoolChooserDialog`. A cross-clan note shows the XP cost and the freeze consequence.
2. **Trapped with no "Choose Origin" button.** `inscribePerk` appended the advancement directly, bypassing `purchase_advancement`'s `can_buy_advancements` gate, so a player could buy an advantage before the origin, spend XP, and freeze themselves out of the (now hidden) Choose Origin button. Now gated, nudging with the same notice toast skills/traits use.
3. **Merits/flaws before origin** now raise the "choose your origin first" toast instead of silently recording.

### API surface
- `api.character.set_origin` gains `buy_different_school`.
- Controller gains `clanOfSchool` / `differentSchoolCost`; `setOrigin` is now 4-arg (default keeps Python callers valid).

## Tests
Added `test_inscribePerk_before_origin_is_refused_with_notice`. Full suite green (162 tests), flake8 clean, qmllint error-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)