### PR TITLE
feat(qml): swap a school-granted spell in place

### DIFF
--- a/l5r/api/character/spells.py
+++ b/l5r/api/character/spells.py
@@ -255,6 +255,44 @@ def add_school_spell(spell_id):
     return True
 
 
+def replace_school_spell(old_spell_id, new_spell_id):
+    """swap a school-granted spell for another, in place, within the rank
+    advancement that granted it.
+
+    This is a correction / GM-override tool. Unlike add_school_spell it is
+    not tied to a pending grant slot and applies *no* eligibility gate --
+    the caller (the QML swap picker) decides what is legal, so a GM can
+    substitute a spell that lies beyond the character's present reach.
+    Returns True on success; False if the old spell is not a school spell,
+    the new spell is unknown to the data store, or the new spell is already
+    known by the character (which would create a duplicate)."""
+    if not old_spell_id or not new_spell_id or old_spell_id == new_spell_id:
+        return False
+
+    new_spell_ = api.data.spells.get(new_spell_id)
+    if not new_spell_:
+        log.api.error(u"replace_school_spell. spell not found: %s", new_spell_id)
+        return False
+
+    # Refuse a swap that would duplicate a spell the character already
+    # knows through any channel (another rank grant, a free-form learn).
+    already_known = set(get_all())
+    already_known.discard(old_spell_id)
+    if new_spell_id in already_known:
+        log.api.warning(
+            u"replace_school_spell. %s already known; refusing swap", new_spell_id)
+        return False
+
+    for r in api.character.rankadv.get_all():
+        if old_spell_id in r.spells:
+            r.spells[r.spells.index(old_spell_id)] = new_spell_id
+            return True
+
+    log.api.warning(
+        u"replace_school_spell. %s is not a school spell", old_spell_id)
+    return False
+
+
 def add_spell(spell_id):
     """add a spell, not bound to a specific rank advancement"""
     spell_ = api.data.spells.get(spell_id)

--- a/l5r/api/tests/test_character.py
+++ b/l5r/api/tests/test_character.py
@@ -300,6 +300,45 @@ class TestCharacterBll(unittest.TestCase):
         self.assertEqual(0, api.character.rankadv.get_pending_spells_count())
         self.assertEqual([], api.character.rankadv.get_starting_spells_to_choose())
 
+    def test_replace_school_spell(self):
+        """replace_school_spell swaps a granted spell in place on its owning
+        rank, without touching the rest of the rank; it refuses unknown
+        targets, duplicates, and non-school spells."""
+        import l5r.api.character.rankadv
+        import l5r.api.character.schools
+        import l5r.api.character.spells
+        from l5rdal.spell import Spell
+
+        for sid, name, elem in (('spell_a', 'Spell A', 'fire'),
+                                ('spell_b', 'Spell B', 'water'),
+                                ('spell_c', 'Spell C', 'air')):
+            sp = Spell()
+            sp.id, sp.name, sp.element, sp.mastery = sid, name, elem, 1
+            api.data.model().spells.append(sp)
+
+        api.character.schools.set_first('test_school_1')
+        rank_ = api.character.rankadv.get_last()
+        rank_.gained_spells_count = 2
+        api.character.spells.add_school_spell('spell_a')
+        api.character.spells.add_school_spell('spell_b')
+        api.character.rankadv.clear_spells_to_choose()
+
+        # A plain swap: spell_a -> spell_c, in place.
+        self.assertTrue(
+            api.character.spells.replace_school_spell('spell_a', 'spell_c'))
+        school_spells = api.character.spells.get_school_spells()
+        self.assertIn('spell_c', school_spells)
+        self.assertNotIn('spell_a', school_spells)
+        self.assertIn('spell_b', school_spells)   # untouched
+
+        # Unknown target, duplicate, and non-school source are all refused.
+        self.assertFalse(
+            api.character.spells.replace_school_spell('spell_c', 'no_such_spell'))
+        self.assertFalse(
+            api.character.spells.replace_school_spell('spell_c', 'spell_b'))
+        self.assertFalse(
+            api.character.spells.replace_school_spell('not_a_school_spell', 'spell_a'))
+
     # --- reset advancements (QML resetAdvancements slot) --------------
 
     def test_reset_advancements(self):

--- a/l5r/qmlui/proxies/app_controller.py
+++ b/l5r/qmlui/proxies/app_controller.py
@@ -1198,6 +1198,21 @@ class AppController(QObject):
             api.character.set_dirty_flag(True)
             api.character.notify_character_refreshed()
 
+    @Slot(str, str)
+    def replaceSchoolSpell(self, old_id, new_id):
+        """Swap a school-granted spell for another, in place, in the rank
+        that granted it -- the '換' (change) handle on a SCHOOL spell card.
+        A correction / GM-override tool: unlike the school-spell grant it
+        applies no eligibility gate, so the picker may offer (and a GM may
+        choose) a spell beyond the character's present reach. The api
+        helper mutates the rank directly and does not own the dirty flag,
+        so this slot does (mirrors applySchoolSpellChoices)."""
+        if not old_id or not new_id:
+            return
+        if api.character.spells.replace_school_spell(old_id, new_id):
+            api.character.set_dirty_flag(True)
+            api.character.notify_character_refreshed()
+
     @Slot(str)
     def memorizeSpell(self, spell_id):
         """Memorize a spell -- a MemoSpellAdv costing XP equal to the

--- a/l5r/qmlui/qml/dialogs/BuySpellDialog.qml
+++ b/l5r/qmlui/qml/dialogs/BuySpellDialog.qml
@@ -36,7 +36,11 @@
 //     description:  "...",
 //     reach:        4,             // highest mastery the caster can learn
 //     eligible:     true }
-// On accept the dialog calls appCtrl.learnSpell(id).
+// Opened two ways:
+//   present()               -- learn free-form; accept -> learnSpell(id).
+//   presentSwap(oldId, name) -- replace a school-granted spell; accept ->
+//                              replaceSchoolSpell(oldId, id). No reach gate
+//                              (a GM correction), so any spell is pickable.
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -48,6 +52,15 @@ Widgets.L5RDialog {
     id: dlg
 
     // --- state ----------------------------------------------------
+    // Two modes share this catalogue picker. "learn" (the default) adds a
+    // free-form spell, gated on mastery-reach. "swap" replaces one
+    // school-granted spell with another -- a correction / GM-override, so
+    // it is NOT gated: any spell may be chosen (out-of-reach ones stay
+    // dimmed as a warning, but remain pickable).
+    property string _mode: "learn"
+    property string _swapOldId: ""
+    property string _swapOldName: ""
+
     property var _catalogue: []
     property var _selected: null
     property string _search: ""
@@ -131,27 +144,42 @@ Widgets.L5RDialog {
 
     // --- chrome (via L5RDialog) -----------------------------------
     seal: "呪"
-    title: qsTr("Learn a Spell")
-    tagline: qsTr("a spell is yours to inscribe only when your understanding runs deep enough")
+    title: dlg._mode === "swap" ? qsTr("Change a Spell") : qsTr("Learn a Spell")
+    tagline: dlg._mode === "swap" ? qsTr("choose another prayer to take the place of the one your school granted") : qsTr("a spell is yours to inscribe only when your understanding runs deep enough")
     accent: _accent
     accentDark: Theme.secondaryDark
-    acceptText: qsTr("Learn")
+    acceptText: dlg._mode === "swap" ? qsTr("Change") : qsTr("Learn")
     acceptGlyph: "呪"
-    acceptEnabled: dlg._eligible
+    // Learn gates on mastery-reach; swap is a GM override, so any picked
+    // spell may be confirmed (the reach box still warns when out of reach).
+    acceptEnabled: dlg._mode === "swap" ? (dlg._selected !== null) : dlg._eligible
     statusText: {
         if (!dlg._selected)
             return "";
+        if (dlg._mode === "swap") {
+            if (dlg._eligible)
+                return qsTr("Replace %1 with this spell.").arg(dlg._swapOldName);
+            return qsTr("This lies beyond the character's present reach — swap it in anyway as the GM decrees.");
+        }
         if (dlg._eligible)
             return qsTr("This spell is within your reach — inscribe it into your library at no cost.");
         return dlg._reasonFor(dlg._selected);
     }
     onAccepted: {
-        if (dlg._selected && dlg._eligible && appCtrl)
+        if (!dlg._selected || !appCtrl)
+            return;
+        if (dlg._mode === "swap") {
+            if (dlg._swapOldId)
+                appCtrl.replaceSchoolSpell(dlg._swapOldId, dlg._selected.id);
+        } else if (dlg._eligible) {
             appCtrl.learnSpell(dlg._selected.id);
+        }
     }
 
-    // --- entrypoint -----------------------------------------------
-    function present() {
+    // --- entrypoints ----------------------------------------------
+    // Shared reset for both modes -- refresh the catalogue and clear the
+    // selection and filters.
+    function _reset() {
         dlg._refreshCatalogue();
         dlg._selected = null;
         dlg._search = "";
@@ -159,6 +187,25 @@ Widgets.L5RDialog {
         dlg._tagMode = "all";
         dlg._tagKey = "";
         tagCombo.currentIndex = 0;
+    }
+
+    // Learn a spell free-form (the default).
+    function present() {
+        dlg._mode = "learn";
+        dlg._swapOldId = "";
+        dlg._swapOldName = "";
+        dlg._reset();
+        dlg.open();
+    }
+
+    // Replace a school-granted spell (oldId) with another. The same
+    // catalogue feed applies -- spells the character already knows are
+    // excluded, so a swap can never duplicate an existing spell.
+    function presentSwap(oldId, oldName) {
+        dlg._mode = "swap";
+        dlg._swapOldId = oldId || "";
+        dlg._swapOldName = oldName || "";
+        dlg._reset();
         dlg.open();
     }
 

--- a/l5r/qmlui/qml/sections/SpellsSection.qml
+++ b/l5r/qmlui/qml/sections/SpellsSection.qml
@@ -20,8 +20,9 @@
 //
 // A spell reaches the register through one of three channels, flagged so
 // the card can act on each correctly:
-//   - SCHOOL    -- granted by a rank advancement; not removable here
-//                  (managed on Advancements).
+//   - SCHOOL    -- granted by a rank advancement; not removable here, but
+//                  swappable in place (change one granted spell for another
+//                  without unwinding the rank -- a correction / GM override).
 //   - LEARNED   -- a free-form spell, learned at no cost; removable.
 //   - MEMORIZED -- carries an XP cost equal to its mastery; can be
 //                  forgotten (refunding the cost).
@@ -50,7 +51,8 @@
 //   pcProxy.isShugenja : bool
 // Required controller methods on appCtrl:
 //   learnSpell(id) · removeSpell(id) · memorizeSpell(id) · forgetSpell(id)
-//   availableSpellsToBuy() -> [...]  (consumed by the dialog)
+//   replaceSchoolSpell(oldId, newId)   (the school-spell swap)
+//   availableSpellsToBuy() -> [...]  (consumed by the dialog, both modes)
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -114,6 +116,16 @@ ColumnLayout {
     function _requestRemove(item) {
         if (item && appCtrl)
             appCtrl.removeSpell(item.id);
+    }
+
+    // Change a school-granted spell for another. School spells cannot be
+    // removed here (they belong to a rank advancement), but they can be
+    // swapped in place -- the fix for a mis-picked spell or a GM-requested
+    // change, without unwinding the whole rank. Reuses the learn dialog in
+    // its "swap" mode (no mastery-reach gate: a GM override).
+    function _requestSwap(item) {
+        if (item && item.id)
+            buySpellDlg.presentSwap(item.id, item.name || "");
     }
 
     // The memorize toggle: forget when already memorized (refunding the
@@ -788,6 +800,50 @@ ColumnLayout {
                         ToolTip.visible: hovered
                         ToolTip.delay: 400
                         ToolTip.text: card._isMemorized ? qsTr("Forget this memorized spell (refunds %1 XP)").arg(card._mastery) : qsTr("Memorize this spell (%1 XP)").arg(card._mastery)
+                    }
+                }
+
+                // ---- Swap handle -- hover-revealed, school spells only --
+                // School spells belong to a rank advancement and cannot be
+                // removed here, but they can be swapped in place: a "換"
+                // (change) affordance in the blue action hue, distinct from
+                // the gold memorize toggle and the crimson remove cross.
+                // A correction / GM-override, so it has no reach gate.
+                Item {
+                    Layout.preferredWidth: 22
+                    Layout.preferredHeight: 22
+                    Layout.alignment: Qt.AlignVCenter
+                    visible: card._isSchool
+
+                    AbstractButton {
+                        id: swapBtn
+                        anchors.fill: parent
+                        visible: cardHover.hovered || swapBtn.hovered
+                        onClicked: section._requestSwap(card.item)
+
+                        background: Rectangle {
+                            radius: 11
+                            color: swapBtn.hovered ? Theme.secondary : "transparent"
+                            border.color: Theme.secondary
+                            border.width: 1
+                            opacity: swapBtn.hovered ? 1.0 : 0.55
+                            Behavior on opacity {
+                                NumberAnimation {
+                                    duration: 120
+                                }
+                            }
+                        }
+                        contentItem: Label {
+                            text: "換"   // exchange -- swap this school spell
+                            font.family: Theme.fontKanji
+                            font.pixelSize: 12
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            color: swapBtn.hovered ? Theme.whiteWash : Theme.secondary
+                        }
+                        ToolTip.visible: hovered
+                        ToolTip.delay: 400
+                        ToolTip.text: qsTr("Change this school spell")
                     }
                 }
 

--- a/l5r/qmlui/tests/test_app_controller.py
+++ b/l5r/qmlui/tests/test_app_controller.py
@@ -213,6 +213,37 @@ class TestControllerActions(unittest.TestCase):
         self.assertEqual([], pc.advans)
         self.assertTrue(pc.unsaved)
 
+    # --- school-spell swap (replaceSchoolSpell slot) -----------------
+
+    def test_replace_school_spell_slot(self):
+        """The replaceSchoolSpell slot swaps a granted spell in place and
+        leaves the model dirty; a swap the api refuses (unknown target)
+        leaves both the spell and the clean flag untouched."""
+        from l5rdal.spell import Spell
+
+        for sid, elem in (('spell_a', 'fire'), ('spell_b', 'water')):
+            sp = Spell()
+            sp.id, sp.name, sp.element, sp.mastery = sid, sid.upper(), elem, 1
+            api.data.model().spells.append(sp)
+
+        api.character.schools.set_first('test_school_1')
+        api.character.rankadv.get_last().gained_spells_count = 1
+        api.character.spells.add_school_spell('spell_a')
+        api.character.set_dirty_flag(False)
+
+        self.ctrl.replaceSchoolSpell('spell_a', 'spell_b')
+
+        school_spells = api.character.spells.get_school_spells()
+        self.assertIn('spell_b', school_spells)
+        self.assertNotIn('spell_a', school_spells)
+        self.assertTrue(api.character.model().unsaved)
+
+        # A refused swap (unknown target) is a silent no-op: no dirtying.
+        api.character.set_dirty_flag(False)
+        self.ctrl.replaceSchoolSpell('spell_b', 'no_such_spell')
+        self.assertIn('spell_b', api.character.spells.get_school_spells())
+        self.assertFalse(api.character.model().unsaved)
+
     # --- File > Open missing-datapack gate ---------------------------
 
     def test_file_open_refused_on_missing_books(self):


### PR DESCRIPTION
School spells live on a rank advancement and could not be corrected: a mis-picked spell (or a GM-requested change) forced unwinding the whole rank on the Advancements tab, losing its school/skills/affinities too.

Add an in-place swap:
- api.character.spells.replace_school_spell(old, new) rewrites the id on the owning rank; no eligibility gate (a correction / GM override), refusing only unknown targets, duplicates, and non-school sources.
- AppController.replaceSchoolSpell slot delegates and owns the dirty flag.
- BuySpellDialog gains a "swap" mode (presentSwap) reusing the catalogue feed; accept is not reach-gated, so out-of-reach spells stay dimmed but pickable.
- SpellsSection shows a hover-revealed 換 handle on SCHOOL cards (blue, distinct from the gold memorize and crimson remove handles).

Tests: api-level replace_school_spell branches + controller-level slot (swap dirties the model; a refused swap is a silent no-op).